### PR TITLE
LIBSEARCH-1. Fixed JavaScript issue with Rails url_helpers

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,5 +11,11 @@ module SearchUmd
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+
+    # Since some of the Quick Search JavaScript files use Rails url_helpers,
+    # the RAILS_RELATIVE_URL_ROOT setting needs to be configured
+    relative_url_root = ENV['RAILS_RELATIVE_URL_ROOT'] || ''
+    Rails.application.routes.default_url_options[:script_name] = relative_url_root
+    QuickSearch::Engine.routes.default_url_options[:script_name] = relative_url_root
   end
 end


### PR DESCRIPTION
In Quick Search, some of the JavaScript files, such as
quick_search/app/assets/javascripts/quick_search/event_tracking.js.erb
Rails URL helpers, i.e.

```
url = '<%= url_helper.log_event_path %>';
```

This works correctly in development, because the JavaScript assets
are compiled dynamically, and the relevant configuration is in place.

When running in production, however, the JavaScript assets are
precompiled. In order to get the correct relative url root, the
"config/application.rb" file needs to configure the
"default_url_options" for the routes.

Without this configuration, the JavaScript URLs will use "/" as the
root URL, which will fail when a suburi is used.

https://issues.umd.edu/browse/LIBSEARCH-1