### PR TITLE
LIBSEARCH-1. Added additional test tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@
 # Ignore minitest-ci reports
 test/reports
 
+# Ignore coverage report
+coverage
+
 # Ignore .env .env.production
 .env
 .env.production

--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,12 @@ group :development, :test do
   gem 'byebug', platform: :mri
 end
 
+group :test do
+  gem 'simplecov', '~> 0.15.1', require: false
+  gem 'simplecov-rcov', '~> 0.2.3', require: false
+  gem 'minitest-reporters', '~> 1.1.19'
+end
+
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
   gem 'web-console'
@@ -72,6 +78,10 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+
+  # Code analysis tools
+  gem 'rubocop', '= 0.52.1', require: false
+  gem 'rubocop-checkstyle_formatter', '~> 0.4.0', require: false
 end
 
 group :production do
@@ -80,6 +90,3 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
-
-# Code analysis tools
-gem 'rubocop', '= 0.52.1', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,7 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    ansi (1.5.0)
     arel (7.1.4)
     ast (2.4.0)
     bindex (0.5.0)
@@ -82,6 +83,7 @@ GEM
       sprockets (< 4.0)
     concurrent-ruby (1.0.5)
     crass (1.0.3)
+    docile (1.1.5)
     dotenv (2.2.1)
     dotenv-rails (2.2.1)
       dotenv (= 2.2.1)
@@ -107,6 +109,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    json (2.1.0)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.1.1)
@@ -131,6 +134,11 @@ GEM
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
+    minitest-reporters (1.1.19)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
     modernizr-rails (2.7.1)
     multi_json (1.13.1)
     mysql2 (0.4.10)
@@ -197,6 +205,8 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
+    rubocop-checkstyle_formatter (0.4.0)
+      rubocop (>= 0.35.1)
     ruby-progressbar (1.9.0)
     sass (3.4.25)
     sass-rails (5.0.7)
@@ -205,6 +215,13 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    simplecov (0.15.1)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
+    simplecov-rcov (0.2.3)
+      simplecov (>= 0.4.1)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -248,6 +265,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)
+  minitest-reporters (~> 1.1.19)
   pg (~> 0.18.4)
   puma (~> 3.0)
   quick_search-arxiv_searcher
@@ -258,7 +276,10 @@ DEPENDENCIES
   quick_search-wikipedia_searcher
   rails (~> 5.0.0)
   rubocop (= 0.52.1)
+  rubocop-checkstyle_formatter (~> 0.4.0)
   sass-rails (~> 5.0)
+  simplecov (~> 0.15.1)
+  simplecov-rcov (~> 0.2.3)
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Requires:
 * Bundler
 
 ### Setup
+
 1) Clone this repository.
 
 2) Install the dependencies:
@@ -42,9 +43,9 @@ Requires:
 Requires:
 
 * Postgres client to be installed (on RedHat, the "postgresql" and
-"postgresql-devel" packages)
+  "postgresql-devel" packages)
 * MySQL client to be installed (on RedHat, the "mysql-devel"). This is a
-requirement from the NCSU Quick Search Rails engine.
+  requirement from the NCSU Quick Search Rails engine.
 
 The application uses the "dotenv" gem to configure the production environment.
 The gem expects a ".env" file in the root directory to contain the environment
@@ -54,7 +55,5 @@ provided to assist with this process. Simply copy the "env_example" file to
 
 The configured .env file should _not_ be checked into the Git repository, as it
 contains credential information.
-
-
 
 [1]: https://github.com/NCSU-Libraries/quick_search

--- a/test/integration/home_page_test.rb
+++ b/test/integration/home_page_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+# Integration test for the Auto Numbers index
+class HomePageTest < ActionDispatch::IntegrationTest
+  test 'home page can be retrieved' do
+    get '/'
+    assert_response :success
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,16 @@
+require 'simplecov'
+require 'simplecov-rcov'
+SimpleCov.formatters = [
+  SimpleCov::Formatter::HTMLFormatter,
+  SimpleCov::Formatter::RcovFormatter
+]
+SimpleCov.start
+
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
+require 'minitest/reporters'
+Minitest::Reporters.use!
 
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.


### PR DESCRIPTION
Added testing tools typically used on Rails projects:

* minitest-reporters for prettier minitest output
* simplecov (and simplecov-rcov) for coverage reports
* rubocop-checkstyle_formatter used with Jenkins for generating Rubocop
  report.

Added a simple integration test.

https://issues.umd.edu/browse/LIBSEARCH-1
