### PR TITLE
LIBSEARCH-9. Changed Gemfile to used "0.2.0" tag of quick_search-core

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,9 +32,7 @@ gem 'jbuilder', '~> 2.5'
 # dotenv - For storing production configuration parameters
 gem 'dotenv-rails', '~> 2.2.1'
 
-# Using "master" branch, because tagged versions are old
-gem 'quick_search-core',
-    git: 'https://github.com/NCSU-Libraries/quick_search.git'
+gem 'quick_search-core', git: 'https://github.com/NCSU-Libraries/quick_search.git', tag: '0.2.0'
 
 # -Inserted by QuickSearch-
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
   remote: https://github.com/NCSU-Libraries/quick_search.git
   revision: 26a840f5d3157ee360249f18c71ed2a3cb3697fa
+  tag: 0.2.0
   specs:
     quick_search-core (0.2.0)
       fastimage


### PR DESCRIPTION
Changed Gemfile to use the tagged 0.2.0 of quick_search-core. This is
that same GitHub commit as has being used before from the "develop"
branch, so it should not change the application.

https://issues.umd.edu/browse/LIBSEARCH-9