### PR TITLE
LIBSEARCH-23. Fixed database names and updated lib_guides searcher in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ GIT
 
 GIT
   remote: https://github.com/umd-lib/quick_search-lib_guides_searcher.git
-  revision: 67d30e190945c870cb51b39d64fc3ce19302a0ce
+  revision: b00e9bdc878eea3c890c23c6a817648be1886471
   branch: develop
   specs:
     quick_search-lib_guides_searcher (0.1.0)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,6 +43,11 @@ en:
     no_results_service_message: "a different search from Research Guides"
     no_results_link: "http://lib.guides.umd.edu/"
 
-en:
   database_finder_search:
+    display_name: "Databases"
+    short_display_name: "Databases"
+    search_form_placeholder: "Search Databases"
+    module_callout: "Search Databases"
+    error_service_message: "searching Databases"
+    no_results_service_message: "a different search from Databases"
     no_results_link: "http://localhost:8080/site/dbfinder"


### PR DESCRIPTION
Fixed issue in en.yml file which was preventing it from being processed.

Updated quick_search-lib_guides_searcher to latest development commit in Gemfile.lock

https://issues.umd.edu/browse/LIBSEARCH-23