### PR TITLE
LIBSEARCH-32. Updated Database Finder REST API endpoint

### DIFF
--- a/config/searchers/database_finder_config.yml
+++ b/config/searchers/database_finder_config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
-  search_url: "<%= ENV['DATABASE_FINDER_HIPPO_SITE_URL'] %>/dbfinder/restapi/v1/search"
+  search_url: "<%= ENV['DATABASE_FINDER_HIPPO_SITE_URL'] %>restservices/v1/dbfinder/search"
   query_params: '?q='
-  loaded_link: "<%= ENV['DATABASE_FINDER_HIPPO_SITE_URL'] %>/dbfinder/list?queryScope=all&query="
+  loaded_link: "<%= ENV['DATABASE_FINDER_HIPPO_SITE_URL'] %>dbfinder/list?queryScope=all&query="
 
 development:
   <<: *defaults


### PR DESCRIPTION
The Database Finder REST API endpoint was changed as part of LIBWEB-4158
from

<SERVER_URL>/dbfinder/restapi/v1/search

to

<SERVER_URL>/dbfinder/list?queryScope=all&query=

This change simply updates the URL in the searchumd configuration.

https://issues.umd.edu/browse/LIBSEARCH-32