### PR TITLE
LIBSEARCH-27 Remove un-needed import from application.css

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1,2 +1,1 @@
 @import "quick_search";
-@import "quick_search_umd_theme";


### PR DESCRIPTION
The quick_search engine handles asset imports for the theme. Adding it
to the manifest causes the compiled assets to swell to a very large size

https://issues.umd.edu/browse/LIBSEARCH-27