### PR TITLE
LIBSEARCH-52. Added start script for Rails application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,9 @@ RUN cd /home/app/webapp && \
 # Copy the main application.
 COPY  --chown=app:app . /home/app/webapp/
 
+# Copy Rails application start script
+COPY --chown=app:app docker_config/searchumd/rails_start.sh /home/app/webapp
+
 ENV RAILS_RELATIVE_URL_ROOT=/search
 ENV SCRIPT_NAME=/search
 
@@ -58,7 +61,5 @@ RUN cd /home/app/webapp && \
 # from the outside.
 EXPOSE 3000
 
-# The main command to run when the container starts. Also
-# tell the Rails dev server to bind to all interfaces by
-# default.
-CMD cd /home/app/webapp && bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0
+# The main command to run when the container starts.
+CMD ["/home/app/webapp/rails_start.sh"]

--- a/docker_config/searchumd/rails_start.sh
+++ b/docker_config/searchumd/rails_start.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+cd /home/app/webapp
+bundle exec rails db:migrate
+
+# Use "exec" to start Rails so that the application will receive the SIGTERM
+# sent to the root process (PID 1), giving the application a chance to
+# gracefully shutdown.
+exec bundle exec rails server -b 0.0.0.0


### PR DESCRIPTION
Added a start script for the Rails application, including running the
rails server using "exec". This makes the Rails application run as
PID 1, so it receives the SIGTERM signal sent with "docker stop" is
run, allowing the application to gracefully shutdown.

https://issues.umd.edu/browse/LIBSEARCH-52