### PR TITLE
LIBSEARCH-49. Initial configuration to support Solr-based website search

### DIFF
--- a/Dockerfile-nutch
+++ b/Dockerfile-nutch
@@ -1,0 +1,27 @@
+# Dockerfile for the generating Apache Nutch Docker image
+#
+# To build:
+#
+# docker build -t docker.lib.umd.edu/searchumd-nutch:<VERSION> -f Dockerfile-nutch .
+#
+# where <VERSION> is the Docker image version to create.
+
+# Builder Stage: Build from apache/nutch image, with UMD configuration files
+FROM apache/nutch:release-1.14 as builder
+
+# Copy configuration files
+COPY docker_config/nutch/ /root/nutch/
+
+# Stage 2: Rebuild using smaller base image, and only use JRE
+FROM openjdk:8u171-jre-slim-stretch
+
+WORKDIR /root/nutch
+
+# Install dependencies
+RUN apt-get update -qq
+
+# Set up JAVA_HOME
+RUN echo 'export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64' >> $HOME/.bashrc
+
+# Copy Apache Nutch runtime from "builder" stage into this image.
+COPY --from=builder /root/nutch_source/runtime/local/ /root/nutch/

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ for use in production:
 * Dockerfile - Generates image for the searchumd Rails application
 * Dockerfile-nginx - Generates image for the Nginx web server providing HTTPS
     and port redirection.
-* Dockerfile-solr - Generates images for the Solr search application
+* Dockerfile-solr - Generates image for the Solr search application
+* Dockerfile-nutch - Generates image for Apache Nutch application with UMD
+    custom configuration
 
 The "docker_config" directory contains files used by the Dockerfiles.
 

--- a/config/searchers/library_website_config.yml
+++ b/config/searchers/library_website_config.yml
@@ -4,12 +4,16 @@
 # your installation.
 #
 # <SEARCH_URL>: The URL for performing the search
-# <QUERY_PARAMS>: Any HTTP query parameters that should be included in the search
 # <WEBSITE_SEARCH_URL>: The URL for the website search page (with query parameter)
 
 defaults: &defaults
-  search_url: <%= ENV['LIBRARY_WEBSITE_SEARCH_REST_URL'] %>
-  query_params: '?pageSize=3&q='
+  search_url: <%= ENV['LIBRARY_WEBSITE_SEARCH_SOLR_URL'] %>
+  # Query params should be listed in "hash" format
+  query_params:
+    # The number of results to return
+    rows: 3
+    # Template for the "q" parameter. SEARCH_TERM will be replaced with the URI escaped search term
+    q_template: 'content:SEARCH_TERM'
   loaded_link: '<WEBSITE_SEARCH_URL>'
 
 development:

--- a/docker_config/nutch/conf/nutch-site.xml
+++ b/docker_config/nutch/conf/nutch-site.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<!-- Put site-specific property overrides in this file. -->
+
+<configuration>
+  <property>
+    <name>http.agent.name</name>
+    <value>http.umd_libraries.umdsearch_crawler</value>
+  </property>
+  <property>
+    <name>http.agent.description</name>
+    <value>Nutch Crawler for umdsearch</value>
+    <description>Further description of our bot- this text is used in
+    the User-Agent header.  It appears in parenthesis after the agent name.
+    </description>
+  </property>
+  <property>
+    <name>http.agent.url</name>
+    <value>https://www.lib.umd.edu/</value>
+    <description>A URL to advertise in the User-Agent header.  This will 
+     appear in parenthesis after the agent name. Custom dictates that this
+     should be a URL of a page explaining the purpose and behavior of this
+     crawler.
+    </description>
+  </property>
+  <property>
+    <name>http.agent.email</name>
+    <value>lib-ssdr@umd.edu</value>
+    <description>An email address to advertise in the HTTP 'From' request
+     header and User-Agent header. A good practice is to mangle this
+     address (e.g. 'info at example dot com') to avoid spamming.
+    </description>
+  </property>
+  <property>
+    <name>http.agent.version</name>
+    <value>Nutch-1.14</value>
+    <description>A version string to advertise in the User-Agent 
+     header.</description>
+  </property>
+  <property>
+    <name>linkdb.ignore.internal.links</name>
+    <value>false</value>
+    <description>If true, when adding new links to a page, links from
+      the same host are ignored.  This is an effective way to limit the
+      size of the link database, keeping only the highest quality
+      links.
+    </description>
+  </property>
+  <property>
+    <name>http.redirect.max</name>
+    <value>1</value>
+    <description>The maximum number of redirects the fetcher will follow when
+    trying to fetch a page. If set to negative or 0, fetcher won't immediately
+    follow redirected URLs, instead it will record them for later fetching.
+    </description>
+  </property>
+  <property>
+    <name>db.fetch.interval.default</name>
+    <value>86400</value>
+    <description>The default number of seconds between re-fetches of a page (30 days).
+    </description>
+  </property>
+  <property>
+    <name>fetcher.server.delay</name>
+    <value>1.0</value>
+    <description>The number of seconds the fetcher will delay between 
+     successive requests to the same server. Note that this might get
+     overridden by a Crawl-Delay from a robots.txt and is used ONLY if 
+     fetcher.threads.per.queue is set to 1.
+     </description>
+  </property>
+</configuration>

--- a/docker_config/nutch/conf/regex-urlfilter.txt
+++ b/docker_config/nutch/conf/regex-urlfilter.txt
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# The default url filter.
+# Better for whole-internet crawling.
+
+# Each non-comment, non-blank line contains a regular expression
+# prefixed by '+' or '-'.  The first matching pattern in the file
+# determines whether a URL is included or ignored.  If no pattern
+# matches, the URL is ignored.
+
+# skip file: ftp: and mailto: urls
+-^(file|ftp|mailto):
+
+# skip image and other suffixes we can't yet parse
+# for a more extensive coverage use the urlfilter-suffix plugin
+-(?i)\.(gif|jpg|png|ico|css|sit|eps|wmf|zip|ppt|mpg|xls|gz|rpm|tgz|mov|exe|jpeg|bmp|js)$
+
+# skip URLs containing certain characters as probable queries, etc.
+-[?*!@=]
+
+# skip URLs with slash-delimited segment that repeats 3+ times, to break loops
+-.*(/[^/]+)/[^/]+\1/[^/]+\1/
+
+# reject DBfinder URLs
+-^https?://(www\.)*lib\.umd\.edu/dbfinder
+
+# accept UMD Libraries URLs
++^https?://(www\.)*lib\.umd\.edu
+
+# reject anything else
+-.

--- a/docker_config/nutch/urls/seed.txt
+++ b/docker_config/nutch/urls/seed.txt
@@ -1,0 +1,1 @@
+https://www.lib.umd.edu/

--- a/env_example
+++ b/env_example
@@ -61,5 +61,5 @@ LIB_GUIDES_API_KEY=
 DATABASE_FINDER_HIPPO_SITE_URL=
 
 # -- config/searchers/library_website_config.yml
-# The Library Website Search REST API URL endpoint
-LIBRARY_WEBSITE_SEARCH_REST_URL=
+# The Library Website Search Solr endpoint
+LIBRARY_WEBSITE_SEARCH_SOLR_URL=


### PR DESCRIPTION
Modified the configuration to enable Solr server to be specified for
the library website searcher.

Added information to the README.md about setting up a Solr server for
use in the development environment.

https://issues.umd.edu/browse/LIBSEARCH-49