### PR TITLE
LIBSEARCH-54. Updated search query to use "text" Solr field

### DIFF
--- a/Dockerfile-nutch
+++ b/Dockerfile-nutch
@@ -6,8 +6,31 @@
 #
 # where <VERSION> is the Docker image version to create.
 
-# Builder Stage: Build from apache/nutch image, with UMD configuration files
-FROM apache/nutch:release-1.14 as builder
+# The "builder" stage of this Dockerfile is largely taken from the apache/nutch
+# Dockerfile (https://hub.docker.com/r/apache/nutch/~/dockerfile/), substituting
+# the UMD Apache Nutch Git repository in place of the official Apache Nutch
+# repository.
+
+FROM ubuntu:16.04 as builder
+
+WORKDIR /root/
+
+# Install dependencies
+RUN apt update
+RUN apt install -y ant openssh-server vim telnet git rsync curl openjdk-8-jdk-headless
+
+# Set up JAVA_HOME
+RUN echo 'export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64' >> $HOME/.bashrc
+
+# The Git branch to build
+ARG NUTCH_REPO=https://github.com/umd-lib/nutch.git
+ARG NUTCH_REPO_BRANCH=umd-develop
+
+# Checkout and build the nutch trunk
+RUN git clone ${NUTCH_REPO} --branch ${NUTCH_REPO_BRANCH} nutch_source && cd nutch_source && ant runtime
+
+# Convenience symlink to Nutch runtime local
+RUN ln -s nutch_source/runtime/local $HOME/nutch
 
 # Copy configuration files
 COPY docker_config/nutch/ /root/nutch/
@@ -21,7 +44,8 @@ WORKDIR /root/nutch
 RUN apt-get update -qq
 
 # Set up JAVA_HOME
-RUN echo 'export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64' >> $HOME/.bashrc
+RUN echo 'export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64' >> /root/.bashrc
 
 # Copy Apache Nutch runtime from "builder" stage into this image.
 COPY --from=builder /root/nutch_source/runtime/local/ /root/nutch/
+

--- a/config/searchers/library_website_config.yml
+++ b/config/searchers/library_website_config.yml
@@ -12,8 +12,9 @@ defaults: &defaults
   query_params:
     # The number of results to return
     rows: 3
-    # Template for the "q" parameter. SEARCH_TERM will be replaced with the URI escaped search term
-    q_template: 'content:SEARCH_TERM'
+    # Template for the "q" parameter. SEARCH_TERM will be replaced with the
+    # URI escaped search term
+    q_template: 'text:SEARCH_TERM'
   loaded_link: '<WEBSITE_SEARCH_URL>'
 
 development:

--- a/docker_config/nutch/conf/nutch-site.xml
+++ b/docker_config/nutch/conf/nutch-site.xml
@@ -5,6 +5,18 @@
 
 <configuration>
   <property>
+    <name>plugin.includes</name>
+    <value>protocol-http|urlfilter-(regex|validator)|parse-(html|tika)|index-(basic|anchor|metadata)|indexer-solr|scoring-opic|urlnormalizer-(pass|regex|basic)|umd-parsefilter-jsonld</value>
+    <description>
+      Regular expression naming plugin directory names to
+      include.  Any plugin not matching this expression is excluded.
+      In any case you need at least include the nutch-extensionpoints plugin. By
+      default Nutch includes crawling just HTML and plain text via HTTP,
+      and basic indexing and search plugins.
+    </description>
+  </property>
+  
+  <property>
     <name>http.agent.name</name>
     <value>http.umd_libraries.umdsearch_crawler</value>
   </property>
@@ -69,5 +81,12 @@
      overridden by a Crawl-Delay from a robots.txt and is used ONLY if 
      fetcher.threads.per.queue is set to 1.
      </description>
+  </property>
+  <property>
+    <name>index.content.md</name>
+    <value>documentContent</value>
+    <description>Comma-separated list of keys to be taken from the content
+    metadata to generate fields.
+    </description>
   </property>
 </configuration>

--- a/docker_config/nutch/conf/solrindex-mapping.xml
+++ b/docker_config/nutch/conf/solrindex-mapping.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<mapping>
+  <!-- Simple mapping of fields created by Nutch IndexingFilters
+       to fields defined (and expected) in Solr schema.xml.
+
+             Any fields in NutchDocument that match a name defined
+             in field/@source will be renamed to the corresponding
+             field/@dest.
+             Additionally, if a field name (before mapping) matches
+             a copyField/@source then its values will be copied to 
+             the corresponding copyField/@dest.
+
+             uniqueKey has the same meaning as in Solr schema.xml
+             and defaults to "id" if not defined.
+         -->
+  <fields>
+    <field dest="content" source="content"/>
+    <field dest="title" source="title"/>
+    <field dest="host" source="host"/>
+    <field dest="segment" source="segment"/>
+    <field dest="boost" source="boost"/>
+    <field dest="digest" source="digest"/>
+    <field dest="tstamp" source="tstamp"/>
+    <field dest="documentContent" source="documentContent"/>
+  </fields>
+  <uniqueKey>id</uniqueKey>
+</mapping>

--- a/docker_config/solr/conf/schema.xml
+++ b/docker_config/solr/conf/schema.xml
@@ -406,6 +406,12 @@
 
     <!-- field containing segment's raw binary content if indexed with -addBinaryContent -->
     <field name="binaryContent" type="binary" stored="true" indexed="false"/>
+    
+    <!-- Field for actual document content from webpage
+         (i.e. JSON-LD WebPage "text", actual text from a Hippo document, etc.)
+         This is distinct from the "content" field, in that it doesn't include
+         extraneous information such as the main menu, sidebar, or footer -->
+    <field name="documentContent" type="text_general" stored="true" indexed="true"/>
 
  </fields>
  <uniqueKey>id</uniqueKey>
@@ -415,6 +421,7 @@
         or to add multiple fields to the same field for easier/faster searching.  -->
 
  <copyField source="content" dest="text"/>
+ <copyField source="documentContent" dest="text"/>
  <copyField source="url" dest="text"/>
  <copyField source="title" dest="text"/>
  <copyField source="anchor" dest="text"/>


### PR DESCRIPTION
Updated the query template for the quick_search-library_website_searcher
to use the "text" Solr field, instead of "content".

https://issues.umd.edu/browse/LIBSEARCH-54