### PR TITLE
LIBSEARCH-42. Moved website "native" interface into searchumd

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Introduction
 
 UMD Libraries bento-box search application, based on the NSCU Quick Search
-Rails engine ([https://github.com/NCSU-Libraries/quick_search][1])
+Rails engine ([https://github.com/NCSU-Libraries/quick_search][quick_search])
 
 This application wraps the NCSU Quick Search engine.
 
@@ -31,18 +31,35 @@ Requires:
 > rails db:reset
 ```
 
-3) To run the web application:
+3) Copy the "env_example" file to ".env" and configure.
+
+4) To run the web application:
 
 ```
 > rails server
 ```
 
-### Development Setup
+## Environment Configuration
+
+Some searchers used by this application require API keys to perform searches.
+To keep these keys secure, and out of the GitHub repository, these keys are
+should be configured through the environment.
+
+The application uses the "dotenv" gem to configure the environment.
+The gem expects a ".env" file in the root directory to contain the environment
+variables that are provided to Rails. A sample "env_example" file has been
+provided to assist with this process. Simply copy the "env_example" file to
+".env" and fill out the parameters as appropriate.
+
+The configured .env file should _not_ be checked into the Git repository, as it
+contains credential information.
+
+## Development Setup
 
 The quick_search-library_website_searcher requires a Solr instance containing
 search results. To set up a Solr instance use one of the following two methods:
 
-#### Method 1: Create and Populating Solr using Nutch
+### Method 1: Create and Populating Solr using Nutch
 
 In this method, a Solr instance will be created and populated using Apache
 Nutch. Use this method if you don't have a Solr data backup.
@@ -58,8 +75,9 @@ Nutch. Use this method if you don't have a Solr data backup.
 ```
 > docker network create dev_network
 ```
+
 2) Run a Docker container with the Solr image, naming it "solr_app", specifying
-the "dev_network", and making it accessible from http://localhost:8983/:
+the "dev_network", and making it accessible from [http://localhost:8983/][solr]:
 
 ```
 > docker run --rm -p 8983:8983 --network dev_network --name solr_app --mount source=solr-data,destination=/opt/solr/server/solr/nutch searchumd-solr:dev
@@ -68,10 +86,9 @@ the "dev_network", and making it accessible from http://localhost:8983/:
 The Solr data will be persisted in a Docker volume named "solr-data" and the
 Solr instance should now be available via a web browser at:
 
-[http://localhost:8983/solr][2]
+[http://localhost:8983/solr][solr]
 
 3) To populate the Solr container, do the following:
-
 
 a) Create a Docker image "searchumd-nutch:dev" using the Dockerfile-nutch:
 
@@ -94,15 +111,15 @@ the following command:
 > docker run --rm --mount source=nutch-data,destination=/root/nutch/LibCrawl --network dev_network searchumd-nutch:dev bin/crawl -i -D solr.server.url=http://solr_app:8983/solr/nutch -s /root/nutch/urls/ LibCrawl/ 2
 ```
 
-#### Method 2: Create and Populating Solr from a Solr backup file
+### Method 2: Create and Populating Solr from a Solr backup file
 
 Use this method if you have a Solr data backup, or can retrieve one from some
 source.
 
-See [https://docs.docker.com/storage/volumes/#backup-restore-or-migrate-data-volumes][3]
+See [https://docs.docker.com/storage/volumes/#backup-restore-or-migrate-data-volumes][docker]
 for more information about backing up and restoring data volumes.
 
-_Creating the Solr Backup_
+#### Creating the Solr Backup
 
 **Note:** This step can be skipped if you already have a Solr data backup.
 
@@ -119,8 +136,7 @@ example) do the following:
 
 This will create a "backup-solr.tar" file in the current directory.
 
-
-_Populating a new data volume_
+#### Populating a new data volume
 
 1) Create a Docker volume named "solr-data":
 
@@ -146,8 +162,9 @@ the volume:
 ```
 > docker network create dev_network
 ```
+
 5) Run a Docker container with the Solr image, naming it "solr_app", specifying
-the "dev_network", and making it accessible from http://localhost:8983/:
+the "dev_network", and making it accessible from [http://localhost:8983/][solr]:
 
 ```
 > docker run --rm -p 8983:8983 --network dev_network --name solr_app --mount source=solr-data,destination=/opt/solr/server/solr/nutch searchumd-solr:dev
@@ -156,22 +173,7 @@ the "dev_network", and making it accessible from http://localhost:8983/:
 The Solr container will now use and persist data in the "solr-data" Docker
 volume. The Solr instance should now be available via a web browser at:
 
-[http://localhost:8983/solr][2]
-
-## Environment Configuration
-
-Some searchers used by this application require API keys to perform searches.
-To keep these keys secure, and out of the GitHub repository, these keys are
-should be configured through the environment.
-
-The application uses the "dotenv" gem to configure the environment.
-The gem expects a ".env" file in the root directory to contain the environment
-variables that are provided to Rails. A sample "env_example" file has been
-provided to assist with this process. Simply copy the "env_example" file to
-".env" and fill out the parameters as appropriate.
-
-The configured .env file should _not_ be checked into the Git repository, as it
-contains credential information.
+[http://localhost:8983/solr][solr]
 
 ## Docker Images
 
@@ -190,6 +192,18 @@ The "docker_config" directory contains files used by the Dockerfiles.
 In order to generate "clean" Docker images, the Docker images should be
 built from a fresh clone of the GitHub repository.
 
-[1]: https://github.com/NCSU-Libraries/quick_search
-[2]: http://localhost:8983/solr
-[3]: https://docs.docker.com/storage/volumes/#backup-restore-or-migrate-data-volumes
+## Additional Functionality
+
+### Website search interface
+
+In addition to the functionality provided by the NSCU Quick Search Rails engine,
+this application also provides a search page for the library website on the
+"website" path (i.e., [http://localhost:3000/website][website].
+
+This functionality uses the quick_search-library_website_searcher to generate
+the results, and so is also dependent on a running Solr instance.
+
+[quick_search]: https://github.com/NCSU-Libraries/quick_search
+[solr]: http://localhost:8983/
+[website]: http://localhost:3000/website
+[docker]: https://docs.docker.com/storage/volumes/#backup-restore-or-migrate-data-volumes

--- a/app/controllers/website_search_controller.rb
+++ b/app/controllers/website_search_controller.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class WebsiteSearchController < ApplicationController
+  helper QuickSearch::ApplicationHelper
+  include QuickSearch::SearcherConcern
+  before_action :assign_search_params
+  layout 'quick_search/application'
+
+  def index
+    do_search
+    @results = Kaminari.paginate_array(@searcher.results, total_count: @searcher.total)
+                       .page(@page).per(@per_page)
+  end
+
+  private
+
+    def do_search
+      @searcher = QuickSearch::LibraryWebsiteSearcher.new(
+        http_client,
+        extracted_query(params_q_scrubbed),
+        @per_page,
+        @offset,
+        @page,
+        on_campus?(ip),
+        extracted_scope(params_q_scrubbed)
+      )
+      @searcher.search
+    end
+
+    def http_client
+      HTTPClient.new
+    end
+
+    def ip
+      request.remote_ip
+    end
+
+    def assign_search_params
+      params[:q] ||= ''
+      @q = params_q_scrubbed
+      @query = @q
+      @per_page = params[:per_page] || 10
+      @page = params[:page] || 1
+      @offset = (@page.to_i - 1) * @per_page
+    end
+end

--- a/app/views/website_search/_results.html.erb
+++ b/app/views/website_search/_results.html.erb
@@ -1,0 +1,8 @@
+<% results.each do |result| %>
+  <div class='row'>
+    <div class='medium-12 columns'>
+      <h3 class='title'><a href='<%= result.link %>'><%= result.title %></a><h3>
+      <p class='description'><%= result.description %></p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/website_search/index.html.erb
+++ b/app/views/website_search/index.html.erb
@@ -1,0 +1,8 @@
+<div class="row">
+    <div class="small-12 medium-6 large-9 columns">
+        <h1>Search Website</h1>
+    </div>
+</div>
+<%= render partial: 'layouts/quick_search/search_form' %>
+<%= render partial: 'results', locals: { results: @results } %>
+<%= paginate @results %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@
 
 Rails.application.routes.draw do
   mount QuickSearch::Engine => '/'
-  mount QuickSearchLibraryWebsiteSearcher::Engine => '/website'
+  root to: 'search#index'
+  get 'website' => 'website_search#index'
+  get 'opensearch' => 'opensearch#opensearch', :defaults => { format: 'xml' }
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/config/searchers/library_website_config.yml
+++ b/config/searchers/library_website_config.yml
@@ -15,7 +15,7 @@ defaults: &defaults
     # Template for the "q" parameter. SEARCH_TERM will be replaced with the
     # URI escaped search term
     q_template: 'text:SEARCH_TERM'
-  loaded_link: '<WEBSITE_SEARCH_URL>'
+  loaded_link: 'website?q='
 
 development:
   <<: *defaults


### PR DESCRIPTION
Moved the controller and views for the website native interface out
of the quick_search-library_website_searcher into searchumd.

This simplifies the searcher, and avoids having to maintain separate
copies of the view templates.

Modified routes.rb, removed QuickSearchLibraryWebsiteSearcher engine,
because it was no longer needed, and added additional routes to satisfy
requirements in the view layouts (when used with the "native" interface)
to have access to certain routes.

https://issues.umd.edu/browse/LIBSEARCH-42