### PR TITLE
LIBSEARCH-63. Updated quick_search-world_cat_discovery_api_searcher

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,12 +62,12 @@ GIT
 
 GIT
   remote: https://github.com/umd-lib/quick_search-world_cat_discovery_api_searcher.git
-  revision: 47759fd80f88c78fc272d98e74625a76bfdc4bf0
+  revision: f57c90decd555cf5cf05435c94c8ecdda8d38d07
   branch: develop
   specs:
     quick_search-world_cat_discovery_api_searcher (0.1.0)
       quick_search-core (~> 0)
-      worldcat-discovery (~> 1.2.0.1)
+      worldcat-discovery (~> 1.2.0.2)
 
 GIT
   remote: https://github.com/umd-lib/quick_search-world_cat_knowledge_base_searcher.git
@@ -237,10 +237,10 @@ GEM
     modernizr-rails (2.7.1)
     multi_json (1.13.1)
     multipart-post (2.0.0)
-    mysql2 (0.5.1)
+    mysql2 (0.5.2)
     netrc (0.11.0)
     nio4r (2.3.1)
-    nokogiri (1.8.2)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     oclc-auth (1.0.0)
       json (~> 2.0, >= 2.0.3)
@@ -263,7 +263,7 @@ GEM
       quick_search-core (~> 0)
     quick_search-wikipedia_searcher (0.0.1)
     rack (2.0.5)
-    rack-test (1.0.0)
+    rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.1.6)
       actioncable (= 5.1.6)
@@ -344,7 +344,7 @@ GEM
     simplecov-html (0.10.2)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    spira (3.0.0.1)
+    spira (3.1.0.1)
       activemodel (~> 5.1)
       activesupport (~> 5.1)
       promise (~> 0.3.0)
@@ -355,7 +355,7 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -386,14 +386,14 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    worldcat-discovery (1.2.0.1)
+    worldcat-discovery (1.2.0.2)
       addressable (~> 2.3, >= 2.3.6)
       equivalent-xml (~> 0.4, >= 0.4.2)
       oclc-auth (~> 1.0, >= 1.0.0)
       rdf (~> 3.0, >= 3.0.0)
       rdf-rdfxml (~> 2.2, >= 2.2.0)
       rest-client (~> 2.0.1, >= 2.0)
-      spira (= 3.0.0.1)
+      spira
 
 PLATFORMS
   ruby
@@ -438,4 +438,4 @@ DEPENDENCIES
   worldcat-discovery (>= 1.2.0.1)
 
 BUNDLED WITH
-   1.16.2
+   1.16.3


### PR DESCRIPTION
Updated quick_search-world_cat_discovery_api_searcher so that
worldcat-discovery gem v1.2.0.1, and spira gem v3.1.0.1 would be
picked up.

This corrects the issue seen in LIBSEARCH-63

https://issues.umd.edu/browse/LIBSEARCH-63