### PR TITLE
LIBSEARCH-16. Updated searchumd to use UMD QuickSearch fork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'jbuilder', '~> 2.5'
 # dotenv - For storing production configuration parameters
 gem 'dotenv-rails', '~> 2.2.1'
 
-gem 'quick_search-core', git: 'https://github.com/NCSU-Libraries/quick_search.git', tag: '0.2.0'
+gem 'quick_search-core', git: 'https://github.com/umd-lib/quick_search.git', tag: '0.2.0'
 
 # -Inserted by QuickSearch-
 

--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'jbuilder', '~> 2.5'
 # dotenv - For storing production configuration parameters
 gem 'dotenv-rails', '~> 2.2.1'
 
-gem 'quick_search-core', git: 'https://github.com/umd-lib/quick_search.git', tag: '0.2.0'
+gem 'quick_search-core', git: 'https://github.com/umd-lib/quick_search.git', branch: 'umd-develop'
 
 # -Inserted by QuickSearch-
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,8 +82,8 @@ GIT
 
 GIT
   remote: https://github.com/umd-lib/quick_search.git
-  revision: 26a840f5d3157ee360249f18c71ed2a3cb3697fa
-  tag: 0.2.0
+  revision: 6758a17d9772f6715381a152f17cfd9ab5d2f348
+  branch: umd-develop
   specs:
     quick_search-core (0.2.0)
       fastimage

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,4 @@
 GIT
-  remote: https://github.com/NCSU-Libraries/quick_search.git
-  revision: 26a840f5d3157ee360249f18c71ed2a3cb3697fa
-  tag: 0.2.0
-  specs:
-    quick_search-core (0.2.0)
-      fastimage
-      httpclient
-      kaminari
-      modernizr-rails
-      mysql2
-      nokogiri
-      rails (~> 5.0)
-
-GIT
   remote: https://github.com/umd-lib/quick_search-database_finder_searcher.git
   revision: f4651a65df987820babf710a9a44d7aa1ed658f4
   branch: develop
@@ -93,6 +79,20 @@ GIT
     quick_search-world_cat_searcher (0.1.0)
       nokogiri (~> 1.6)
       quick_search-core (~> 0)
+
+GIT
+  remote: https://github.com/umd-lib/quick_search.git
+  revision: 26a840f5d3157ee360249f18c71ed2a3cb3697fa
+  tag: 0.2.0
+  specs:
+    quick_search-core (0.2.0)
+      fastimage
+      httpclient
+      kaminari
+      modernizr-rails
+      mysql2
+      nokogiri
+      rails (~> 5.0)
 
 GEM
   remote: https://maven.lib.umd.edu/nexus/content/groups/umd-ruby-gems-repository-group/

--- a/README.md
+++ b/README.md
@@ -2,10 +2,14 @@
 
 ## Introduction
 
-UMD Libraries bento-box search application, based on the NSCU Quick Search
-Rails engine ([https://github.com/NCSU-Libraries/quick_search][quick_search])
+UMD Libraries bento-box search application, based on the NSCU QuickSearch
+Rails engine ([https://github.com/NCSU-Libraries/quick_search][quick_search]).
 
-This application wraps the NCSU Quick Search engine.
+This application wraps the NCSU QuickSearch engine.
+
+Note: This application is currently using a UMD-customized fork of the
+NCSU QuickSearch application at
+[https://github.com/umd-lib/quick_search][umd_quick_search].
 
 ## Quick Start
 
@@ -196,7 +200,7 @@ built from a fresh clone of the GitHub repository.
 
 ### Website search interface
 
-In addition to the functionality provided by the NSCU Quick Search Rails engine,
+In addition to the functionality provided by the NSCU QuickSearch Rails engine,
 this application also provides a search page for the library website on the
 "website" path (i.e., [http://localhost:3000/website][website].
 
@@ -204,6 +208,7 @@ This functionality uses the quick_search-library_website_searcher to generate
 the results, and so is also dependent on a running Solr instance.
 
 [quick_search]: https://github.com/NCSU-Libraries/quick_search
+[umd_quick_search]: https://github.com/umd-lib/quick_search
 [solr]: http://localhost:8983/
 [website]: http://localhost:3000/website
 [docker]: https://docs.docker.com/storage/volumes/#backup-restore-or-migrate-data-volumes

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,37 +13,37 @@
 ActiveRecord::Schema.define(version: 20180221193511) do
 
   create_table "events", force: :cascade do |t|
-    t.string   "category"
-    t.string   "item"
-    t.string   "query"
+    t.string "category"
+    t.string "item"
+    t.string "query"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "action"
-    t.integer  "session_id"
-    t.string   "created_at_string"
+    t.string "action"
+    t.integer "session_id"
+    t.string "created_at_string"
     t.index ["created_at_string"], name: "index_events_on_created_at_string"
     t.index ["session_id"], name: "index_events_on_session_id"
   end
 
   create_table "searches", force: :cascade do |t|
-    t.string   "query"
+    t.string "query"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "page"
-    t.integer  "session_id"
-    t.string   "created_at_string"
+    t.string "page"
+    t.integer "session_id"
+    t.string "created_at_string"
     t.index ["created_at_string"], name: "index_searches_on_created_at_string"
     t.index ["session_id"], name: "index_searches_on_session_id"
   end
 
   create_table "sessions", force: :cascade do |t|
-    t.string   "session_uuid"
+    t.string "session_uuid"
     t.datetime "expiry"
-    t.boolean  "on_campus"
-    t.boolean  "is_mobile"
+    t.boolean "on_campus"
+    t.boolean "is_mobile"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "created_at_string"
+    t.string "created_at_string"
     t.index ["created_at_string"], name: "index_sessions_on_created_at_string"
   end
 


### PR DESCRIPTION
Updated searchumd to use the "umd-develop" branch of the UMD QuickSearch fork
at https://github.com/umd-lib/quick_search.

https://issues.umd.edu/browse/LIBSEARCH-16