### PR TITLE
LIBSEARCH-15 Modified "no_results_link" configuration for searchers

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,7 +29,8 @@ en:
     module_callout: "Search WorldCat (Search)"
     error_service_message: "searching WorldCat (Search)"
     no_results_service_message: "a different search from WorldCat (Search)"
-    no_results_link: "https://umaryland.on.worldcat.org/search"
+    # no_results_link now configured in searcher configuration YAML file
+    no_results_link:
 
   lib_answers_search:
     display_name: "Ask Us!"
@@ -38,7 +39,8 @@ en:
     module_callout: "Search Ask Us!"
     error_service_message: "searching Ask Us!"
     no_results_service_message: "a different search from Ask Us!"
-    no_results_link: "http://umd.libanswers.com/"
+    # no_results_link now configured in searcher configuration YAML file
+    no_results_link:
 
   lib_guides_search:
     display_name: "Research Guides"
@@ -47,7 +49,8 @@ en:
     module_callout: "Search Research Guides"
     error_service_message: "searching Research Guides"
     no_results_service_message: "a different search from Research Guides"
-    no_results_link: "http://lib.guides.umd.edu/"
+    # no_results_link now configured in searcher configuration YAML file
+    no_results_link:
 
   database_finder_search:
     display_name: "Databases"
@@ -56,7 +59,8 @@ en:
     module_callout: "Search Databases"
     error_service_message: "searching Databases"
     no_results_service_message: "a different search from Databases"
-    no_results_link: "http://localhost:8080/site/dbfinder"
+    # no_results_link configured in searcher configuration YAML file
+    no_results_link:
 
   world_cat_knowledge_base_search:
     display_name: "WorldCat Knowledge Base"
@@ -65,7 +69,8 @@ en:
     module_callout: "Search WorldCat Knowledge Base"
     error_service_message: "searching WorldCat Knowledge Base"
     no_results_service_message: "a different search from WorldCat Knowledge Base"
-    no_results_link: "https://umaryland.on.worldcat.org/atoztitles/search#ebook"
+    # no_results_link now configured in searcher configuration YAML file
+    no_results_link:
 
   library_website_search:
     display_name: "Website"
@@ -74,7 +79,8 @@ en:
     module_callout: "Search Website"
     error_service_message: "searching Website"
     no_results_service_message: "a different search from Website"
-    no_results_link: "website"
+    # no_results_link now configured in searcher configuration YAML file
+    no_results_link:
 
   swiftype_search:
     display_name: "Swiftype Library Website"
@@ -83,4 +89,9 @@ en:
     module_callout: "Swiftype Search Library Website"
     error_service_message: "searching Library Website using Swiftype"
     no_results_service_message: "a different search from Library Website using Swiftype"
-    no_results_link: "<NO_RESULTS_LINK>"
+    # no_results_link now configured in searcher configuration YAML file
+    no_results_link:
+
+  world_cat_discovery_api_search:
+    # no_results_link now configured in searcher configuration YAML file
+    no_results_link:

--- a/config/searchers/database_finder_config.yml
+++ b/config/searchers/database_finder_config.yml
@@ -2,6 +2,7 @@ defaults: &defaults
   search_url: "<%= ENV['DATABASE_FINDER_HIPPO_SITE_URL'] %>restservices/v1/dbfinder/search"
   query_params: '?q='
   loaded_link: "<%= ENV['DATABASE_FINDER_HIPPO_SITE_URL'] %>dbfinder/list?queryScope=all&query="
+  no_results_link: "<%= ENV['DATABASE_FINDER_HIPPO_SITE_URL'] %>dbfinder/"
 
 development:
   <<: *defaults

--- a/config/searchers/lib_answers_config.yml
+++ b/config/searchers/lib_answers_config.yml
@@ -2,7 +2,8 @@ defaults: &defaults
   base_url: "https://api2.libanswers.com/1.0/search/"
   query_params: "?iid=<%= ENV['LIB_ANSWERS_IID'] %>&limit=3"
   loaded_link: "http://umd.libanswers.com/search?q="
-  iid: 
+  no_results_link: "http://umd.libanswers.com/search"
+  iid:
 
 development:
   <<: *defaults

--- a/config/searchers/lib_guides_config.yml
+++ b/config/searchers/lib_guides_config.yml
@@ -3,6 +3,7 @@ defaults: &defaults
   query_params: '&site_id=<%= ENV['LIB_GUIDES_SITE_ID'] %>&sort_by=relevance&search_terms='
   loaded_link: 'http://lib.guides.umd.edu/srch.php?q='
   key: <%= ENV['LIB_GUIDES_API_KEY'] %>
+  no_results_link: 'http://lib.guides.umd.edu/srch.php'
 
 development:
   <<: *defaults

--- a/config/searchers/library_website_config.yml
+++ b/config/searchers/library_website_config.yml
@@ -16,6 +16,7 @@ defaults: &defaults
     # URI escaped search term
     q_template: 'text:SEARCH_TERM'
   loaded_link: 'website?q='
+  no_results_link: 'website'
 
 development:
   <<: *defaults

--- a/config/searchers/swiftype_config.yml
+++ b/config/searchers/swiftype_config.yml
@@ -12,6 +12,7 @@ defaults: &defaults
   search_url: 'https://search-api.swiftype.com/api/v1/public/engines/search'
   query_params: '?q='
   loaded_link: 'swiftype#stq='
+  no_results_link: 'swiftype'
 
 development:
   <<: *defaults

--- a/config/searchers/world_cat_config.yml
+++ b/config/searchers/world_cat_config.yml
@@ -2,6 +2,7 @@ defaults: &defaults
   base_url: "http://www.worldcat.org/webservices/catalog/search/worldcat/opensearch?count=3&wskey="
   wskey: <%= ENV['WORLD_CAT_API_WSKEY'] %>
   loaded_link: "https://umaryland.on.worldcat.org/search?queryString="
+  no_results_link: 'https://umaryland.on.worldcat.org/search'
   url_link: "https://umaryland.on.worldcat.org/search?queryString=no%3A+"
 
 development:

--- a/config/searchers/world_cat_discovery_api_config.yml
+++ b/config/searchers/world_cat_discovery_api_config.yml
@@ -4,6 +4,7 @@ defaults: &defaults
   authenticatingInstitutionId: <%= ENV['WORLD_CAT_DISCOVERY_API_INSTITUTION_ID'] %>
   contextInstitutionId: <%= ENV['WORLD_CAT_DISCOVERY_API_INSTITUTION_ID'] %>
   loaded_link: "https://umaryland.on.worldcat.org/search?queryString="
+  no_results_link: 'https://umaryland.on.worldcat.org/search'
   url_link: "https://umaryland.on.worldcat.org/oclc/6032704017"
 
 development:

--- a/config/searchers/world_cat_knowledge_base_config.yml
+++ b/config/searchers/world_cat_knowledge_base_config.yml
@@ -3,6 +3,7 @@ defaults: &defaults
   institution_id: <%= ENV['WORLD_CAT_KNOWLEDGE_BASE_INSTITUTION_ID'] %>
   wskey: <%= ENV['WORLD_CAT_KNOWLEDGE_BASE_WSKEY'] %>
   loaded_link: "https://umaryland.on.worldcat.org/atoztitles/ebooks?searchType=matchAll&btitle="
+  no_results_link: 'https://umaryland.on.worldcat.org/atoztitles/search#ebook'
 
 development:
   <<: *defaults


### PR DESCRIPTION
Added "no_results_link" properties to each of the searcher configuration
YAML files in the config/searchers/ directory. This enables the
"no_results_link" property to be parameterized using environment
variables, if necessary.

In the en.yml file, replaced "no_results_link" entries with nothing
so that the properties in the searcher configuration YAML files will
be used.

https://issues.umd.edu/browse/LIBSEARCH-15