### PR TITLE
LIBSEARCH-70. Remove arXiv, OpenLibrary, Wikipedia, placeholder searc…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,11 +42,6 @@ gem 'quick_search-core', git: 'https://github.com/umd-lib/quick_search.git', bra
 # your config/quick_search_config.yml file as well as references to them in your theme's search
 # results page template
 
-gem 'quick_search-wikipedia_searcher'
-gem 'quick_search-open_library_searcher'
-gem 'quick_search-arxiv_searcher'
-gem 'quick_search-placeholder_searcher'
-
 gem 'quick_search-world_cat_searcher',
     git: 'https://github.com/umd-lib/quick_search-world_cat_searcher.git', branch: 'develop'
 gem 'quick_search-lib_answers_searcher',

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,14 +254,6 @@ GEM
     promise (0.3.1)
     public_suffix (3.0.2)
     puma (3.11.4)
-    quick_search-arxiv_searcher (0.0.1)
-      nokogiri (~> 1.6)
-      quick_search-core (~> 0)
-    quick_search-open_library_searcher (0.0.1)
-      quick_search-core (~> 0)
-    quick_search-placeholder_searcher (0.0.1)
-      quick_search-core (~> 0)
-    quick_search-wikipedia_searcher (0.0.1)
     rack (2.0.5)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -409,17 +401,13 @@ DEPENDENCIES
   oclc-auth (>= 1.0.0)
   pg (~> 0.18.4)
   puma (~> 3.0)
-  quick_search-arxiv_searcher
   quick_search-core!
   quick_search-database_finder_searcher!
   quick_search-lib_answers_searcher!
   quick_search-lib_guides_searcher!
   quick_search-library_website_searcher!
-  quick_search-open_library_searcher
-  quick_search-placeholder_searcher
   quick_search-swiftype_searcher!
   quick_search-umd_theme!
-  quick_search-wikipedia_searcher
   quick_search-world_cat_discovery_api_searcher!
   quick_search-world_cat_searcher!
   rails (~> 5.1.0)

--- a/app/views/quick_search/search/index.html.erb
+++ b/app/views/quick_search/search/index.html.erb
@@ -11,18 +11,8 @@
         </div>
     </div>
 </div>
-<%# FIXME: This logic could stand a second look %>
-<% unless @wikipedia.is_a? StandardError %>
-    <% unless @best_bets.is_a? StandardError %>
-        <% if @best_bets.results.blank? %>
-            <% unless @wikipedia.spelling_suggestion.blank? %>
-                <%= render partial: 'layouts/quick_search/spelling_suggestion', locals: { spelling_suggestion: @wikipedia.spelling_suggestion} %>
-            <% end %>
-        <% end %>
-    <% end %>
-<% else %>
-    <div id="spelling-suggestion" class="hidden"></div>
-<% end %>
+<div id="spelling-suggestion" class="hidden"></div>
+
 <div class="row">
     <div class="small-12 large-8 columns">
         <% if @best_bets.is_a? StandardError %>
@@ -65,27 +55,8 @@
         </div>
         <hr>
     </div>
-    <div class="row journals-databases">
-        <div class="small-12 columns"><h4 class='section-description'>Other Ways to Find Articles</h4></div>
-        <div class="small-12 medium-4 columns journals module">
-          <%= render_module(@arxiv, 'arxiv') %>
-        </div>
-        <div class="small-12 medium-4 columns databases module">
-          <%= render_module(@open_library, 'open_library') %>
-        </div>
-        <div class="small-12 medium-4 columns smart-subjects module">
-          <%= render_module(@wikipedia, 'wikipedia') %>
-        </div>
-        <hr>
-    </div>
     <div class="row website-faq">
         <div class="small-12 columns"><h4 class='section-description'>Information About the Libraries</h4></div>
-        <div class="small-12 medium-4 medium-push-8 columns faq module">
-            <%= render_module(@placeholder, 'placeholder') %>
-        </div>
-        <div class="small-12 medium-8 medium-pull-4 columns website module">
-            <%= render_module(@placeholder, 'placeholder') %>
-        </div>
     </div>
 
     <div class="row">

--- a/config/quick_search_config.yml
+++ b/config/quick_search_config.yml
@@ -18,11 +18,11 @@ defaults: &defaults
   #
   # See docs for more details: https://github.com/NCSU-Libraries/quick_search/blob/master/docs/configuration.md
 
-  searchers: [best_bets,world_cat,world_cat_discovery_api,lib_guides,database_finder,lib_answers,library_website,swiftype,arxiv,open_library,wikipedia,placeholder]
+  searchers: [best_bets,world_cat,world_cat_discovery_api,lib_guides,database_finder,lib_answers,library_website,swiftype]
 
   # Searchers listed in the "result type guide" bar that lists result types that were found for a given search
 
-  found_types: [world_cat,world_cat_discovery_api,lib_guides,database_finder,lib_answers,library_website,swiftype,arxiv,open_library,wikipedia,placeholder,placeholder]
+  found_types: [world_cat,world_cat_discovery_api,lib_guides,database_finder,lib_answers,library_website,swiftype]
 
   per_page: 3
   max_per_page: 50


### PR DESCRIPTION
…hers

Removed the default QuickSearch searchers, at the direction of the
Discovery committee.

Note: The Wikipedia searcher also provided spelling suggestions, so
logic related to spelling suggestions was removed from the
index.html.erb template, but the div itself was retained.

https://issues.umd.edu/browse/LIBSEARCH-70