### PR TITLE
LIBSEARCH-95. Modified display names for Nutch and Swiftype searchers

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,22 +63,22 @@ en:
     no_results_link:
 
   library_website_search:
-    display_name: "Website"
-    short_display_name: "Website"
-    search_form_placeholder: "Search Website"
-    module_callout: "Search Website"
-    error_service_message: "searching Website"
-    no_results_service_message: "a different search from Website"
+    display_name: "Website Option 1"
+    short_display_name: "Website Option 1"
+    search_form_placeholder: "Search Library Website using Option 1"
+    module_callout: "Search Website Option 1"
+    error_service_message: "searching Library Website using Option 1"
+    no_results_service_message: "a different search from Website Option 1"
     # no_results_link now configured in searcher configuration YAML file
     no_results_link:
 
   swiftype_search:
-    display_name: "Swiftype Library Website"
-    short_display_name: "Swiftype Library Website"
-    search_form_placeholder: "Search Library Website using Swiftype"
-    module_callout: "Swiftype Search Library Website"
-    error_service_message: "searching Library Website using Swiftype"
-    no_results_service_message: "a different search from Library Website using Swiftype"
+    display_name: "Website Option 2"
+    short_display_name: "Website Option 2"
+    search_form_placeholder: "Search Library Website using Option 2"
+    module_callout: "Search Website Option 2"
+    error_service_message: "searching Library Website using Option 2"
+    no_results_service_message: "a different search from Website Option 2"
     # no_results_link now configured in searcher configuration YAML file
     no_results_link:
 


### PR DESCRIPTION
Modified the Apache Nutch searcher display name to "Website Option 1"

Modified the Swiftype searcher display name to "Website Option 2"

https://issues.umd.edu/browse/LIBSEARCH-95