### PR TITLE
LIBSEARCH-77. Removed session_store.rb

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-Rails.application.config.session_store :cookie_store, key: '_searchumd_session'


### PR DESCRIPTION
Removed session_store.rb file, as it is no longer needed for
Rails 5.2.2.1

https://issues.umd.edu/browse/LIBSEARCH-77