### PR TITLE
LIBSEARCH-129. Updated searchumd to use latest NSCU QuickSearch version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,7 @@ GIT
 
 GIT
   remote: https://github.com/umd-lib/quick_search.git
-  revision: b92a6de679b17a194c288386e41c181b19436d08
+  revision: 777121a93e5f6cb267ee5e0292151ecf209263e5
   branch: umd-develop
   specs:
     quick_search-core (0.2.0)


### PR DESCRIPTION
Updated the "searchumd" application to use the latest NCSU QuickSearch
version, via the "umd-develop" branch in the "umd-lib/quick_search"
repository.

This incorporates NSCU pull requests of UMD changes for:

* LIBSEARCH-121
* LIBSEARCH-127
* LIBSEARCH-128

https://issues.umd.edu/browse/LIBSEARCH-129