### PR TITLE
LIBSEARCH-134. Use HTTPS urls for EBSCO host.

### DIFF
--- a/config/searchers/ebsco_discovery_service_api_article_config.yml
+++ b/config/searchers/ebsco_discovery_service_api_article_config.yml
@@ -23,9 +23,9 @@ defaults: &defaults
 
   # ebsco_discovery_service_api-specific properties
   loaded_link: 'http://proxy-um.researchport.umd.edu/login?url=https://search.ebscohost.com/login.aspx?direct=true&site=eds-live&bquery='
-  url_link: 'http://proxy-um.researchport.umd.edu/login?url=https://search.ebscohost.com/login.aspx?direct=true&site=eds-live'
-  doi_link: 'http://proxy-um.researchport.umd.edu/login?url=https://doi.org/'
-  no_results_link: 'http://proxy-um.researchport.umd.edu/login?url=https://search.ebscohost.com/login.aspx?direct=true&site=eds-live'
+  url_link: 'https://proxy-um.researchport.umd.edu/login?url=https://search.ebscohost.com/login.aspx?direct=true&site=eds-live'
+  doi_link: 'https://proxy-um.researchport.umd.edu/login?url=https://doi.org/'
+  no_results_link: 'https://proxy-um.researchport.umd.edu/login?url=https://search.ebscohost.com/login.aspx?direct=true&site=eds-live'
 
 development:
   <<: *defaults

--- a/config/searchers/ebsco_discovery_service_api_config.yml
+++ b/config/searchers/ebsco_discovery_service_api_config.yml
@@ -21,9 +21,9 @@ defaults: &defaults
   password: <%= ENV['EBSCO_DISCOVERY_SERVICE_API_PASSWORD'] %>
 
   # ebsco_discovery_service_api-specific properties
-  loaded_link: 'http://proxy-um.researchport.umd.edu/login?url=https://search.ebscohost.com/login.aspx?direct=true&site=eds-live&bquery='
-  url_link: 'http://proxy-um.researchport.umd.edu/login?url=https://search.ebscohost.com/login.aspx?direct=true&site=eds-live'
-  no_results_link: 'http://proxy-um.researchport.umd.edu/login?url=https://search.ebscohost.com/login.aspx?direct=true&site=eds-live'
+  loaded_link: 'https://proxy-um.researchport.umd.edu/login?url=https://search.ebscohost.com/login.aspx?direct=true&site=eds-live&bquery='
+  url_link: 'https://proxy-um.researchport.umd.edu/login?url=https://search.ebscohost.com/login.aspx?direct=true&site=eds-live'
+  no_results_link: 'https://proxy-um.researchport.umd.edu/login?url=https://search.ebscohost.com/login.aspx?direct=true&site=eds-live'
 
 development:
   <<: *defaults


### PR DESCRIPTION
https://issues.umd.edu/browse/LIBSEARCH-134