### PR TITLE
LIBSEARCH-143. Library website native interface link now uses "query"

### DIFF
--- a/app/controllers/website_search_controller.rb
+++ b/app/controllers/website_search_controller.rb
@@ -17,12 +17,12 @@ class WebsiteSearchController < ApplicationController
     def do_search
       @searcher = QuickSearch::LibraryWebsiteSearcher.new(
         http_client,
-        extracted_query(params_q_scrubbed),
+        extracted_query(@q),
         @per_page,
         @offset,
         @page,
         on_campus?(ip),
-        extracted_scope(params_q_scrubbed)
+        extracted_scope(@q)
       )
       @searcher.search
     end
@@ -36,8 +36,10 @@ class WebsiteSearchController < ApplicationController
     end
 
     def assign_search_params
-      params[:q] ||= ''
-      @q = params_q_scrubbed
+      # For library website search, query parameter is "query", not "q"
+      # This is so the query parameter is compatible with what is used in Hippo.
+      params[:query] ||= ''
+      @q = params[:query].scrub
       @query = @q
       @per_page = params[:per_page] || 10
       @page = params[:page] || 1

--- a/config/searchers/library_website_config.yml
+++ b/config/searchers/library_website_config.yml
@@ -15,7 +15,7 @@ defaults: &defaults
     # Template for the "q" parameter. SEARCH_TERM will be replaced with the
     # URI escaped search term
     q_template: 'text:SEARCH_TERM'
-  loaded_link: 'website?q='
+  loaded_link: 'website?query='
   no_results_link: 'website'
 
 development:


### PR DESCRIPTION
Modified the library website native interface link to use "query"
instead of "q" for specifying the search term.

This makes the native interface link work with Hippo, where "query"
HTTP parameter is used for the search term.

Modified the website controller in searchumd to also expect the
"query" parameter, instead of "q".

https://issues.umd.edu/browse/LIBSEARCH-143