### PR TITLE
LIBSEARCH-147. Updated WorldCat config to point to better no results URL

### DIFF
--- a/config/searchers/world_cat_discovery_api_article_config.yml
+++ b/config/searchers/world_cat_discovery_api_article_config.yml
@@ -25,7 +25,7 @@ defaults: &defaults
   # world_cat_discovery_api_article-specific properties
   loaded_link: "https://umaryland.on.worldcat.org/search?format=Artchap&queryString="
   url_link: "https://umaryland.on.worldcat.org/oclc/"
-  no_results_link: 'https://umaryland.on.worldcat.org/search'
+  no_results_link: "https://umaryland.on.worldcat.org/discovery"
   doi_link: "http://proxy-um.researchport.umd.edu/login?url="
 
 development:

--- a/config/searchers/world_cat_discovery_api_config.yml
+++ b/config/searchers/world_cat_discovery_api_config.yml
@@ -25,7 +25,7 @@ defaults: &defaults
   # world_cat_discovery_api-specific properties
   loaded_link: "https://umaryland.on.worldcat.org/search?queryString="
   url_link: "https://umaryland.on.worldcat.org/oclc/"
-  no_results_link: 'https://umaryland.on.worldcat.org/search'
+  no_results_link: "https://umaryland.on.worldcat.org/discovery"
 
 development:
   <<: *defaults


### PR DESCRIPTION
Update the "no_results_link" for the world_cat_discovery_api and
world_cat_discovery_api_article searchers to point at a URL that does
not display a warning about an empty query term.

Both searchers still point at the same URL, because there does not
appear to be a way to set a URL that can be limited to articles, for
the "article" searcher.

https://issues.umd.edu/browse/LIBSEARCH-147