### PR TITLE
LIBSEARCH-150. Moved searchers into searchumd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,7 @@ coverage
 # Ignore Bundler vendored files
 vendor/bundle
 
+# Ignore log from "faraday" gem
+faraday.log
+
 .DS_Store

--- a/Gemfile
+++ b/Gemfile
@@ -55,16 +55,52 @@ gem 'quick_search-core', git: 'https://github.com/umd-lib/quick_search.git', bra
 # your config/quick_search_config.yml file as well as references to them in your theme's search
 # results page template
 
-gem 'quick_search-lib_answers_searcher',
-    git: 'https://github.com/umd-lib/quick_search-lib_answers_searcher.git', branch: 'develop'
-gem 'quick_search-lib_guides_searcher',
-    git: 'https://github.com/umd-lib/quick_search-lib_guides_searcher.git', branch: 'develop'
+gem 'quick_search-archives_space_searcher',
+    git: 'https://github.com/umd-lib/quick_search-archives_space_searcher.git',
+    branch: 'develop'
+
 gem 'quick_search-database_finder_searcher',
-    git: 'https://github.com/umd-lib/quick_search-database_finder_searcher.git', branch: 'develop'
+    git: 'https://github.com/umd-lib/quick_search-database_finder_searcher.git',
+    branch: 'develop'
+
+gem 'quick_search-drum_searcher',
+    git: 'https://github.com/umd-lib/quick_search-drum_searcher.git',
+    branch: 'develop'
+
+gem 'quick_search-ebsco_discovery_service_api_searcher',
+    git: 'https://github.com/umd-lib/quick_search-ebsco_discovery_service_api_searcher.git',
+    branch: 'develop'
+
+gem 'quick_search-fedora_searcher',
+    git: 'https://github.com/umd-lib/quick_search-fedora_searcher.git',
+    branch: 'develop'
+
+gem 'quick_search-internet_archive_searcher',
+    git: 'https://github.com/umd-lib/quick_search-internet_archive_searcher',
+    branch: 'develop'
+
+gem 'quick_search-lib_answers_searcher',
+    git: 'https://github.com/umd-lib/quick_search-lib_answers_searcher.git',
+    branch: 'develop'
+
+gem 'quick_search-lib_guides_searcher',
+    git: 'https://github.com/umd-lib/quick_search-lib_guides_searcher.git',
+    branch: 'develop'
+
 gem 'quick_search-library_website_searcher',
-    git: 'https://github.com/umd-lib/quick_search-library_website_searcher.git', branch: 'develop'
+    git: 'https://github.com/umd-lib/quick_search-library_website_searcher.git',
+    branch: 'develop'
+
+gem 'quick_search-maryland_map_searcher',
+    git: 'https://github.com/umd-lib/quick_search-maryland_map_searcher.git',
+    branch: 'develop'
+
 gem 'quick_search-world_cat_discovery_api_searcher',
-    git: 'https://github.com/umd-lib/quick_search-world_cat_discovery_api_searcher.git', branch: 'develop'
+    git: 'https://github.com/umd-lib/quick_search-world_cat_discovery_api_searcher.git',
+    branch: 'develop'
+
+# Dependencies for the quick_search-ebsco_discovery_service_api_searcher initialization script
+gem 'ebsco-eds', '~> 1.0.7'
 
 # Dependencies for the quick_search-world_cat_discovery_api_searcher initialization script
 gem 'oclc-auth', '>=1.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,51 @@
 GIT
+  remote: https://github.com/umd-lib/quick_search-archives_space_searcher.git
+  revision: e9b1b6b4afe2edc1f085d235401778f349f9bcd6
+  branch: develop
+  specs:
+    quick_search-archives_space_searcher (0.1.0)
+      quick_search-core (~> 0)
+
+GIT
   remote: https://github.com/umd-lib/quick_search-database_finder_searcher.git
   revision: 60295f519ea914c0b78579364c9010f1b77cf026
   branch: develop
   specs:
     quick_search-database_finder_searcher (0.1.0)
+      quick_search-core (~> 0)
+
+GIT
+  remote: https://github.com/umd-lib/quick_search-drum_searcher.git
+  revision: cd223573a2d19bda37fc024fd9bd2c050ea2b287
+  branch: develop
+  specs:
+    quick_search-drum_searcher (0.1.0)
+      nokogiri
+      quick_search-core (~> 0)
+
+GIT
+  remote: https://github.com/umd-lib/quick_search-ebsco_discovery_service_api_searcher.git
+  revision: d02b7f5731c6b6929fde7c5390d22bca4a22f151
+  branch: develop
+  specs:
+    quick_search-ebsco_discovery_service_api_searcher (0.1.0)
+      ebsco-eds (~> 1.0.7)
+      quick_search-core (~> 0)
+
+GIT
+  remote: https://github.com/umd-lib/quick_search-fedora_searcher.git
+  revision: 474df6d0891c51481dfed70090ab494359fb3c32
+  branch: develop
+  specs:
+    quick_search-fedora_searcher (0.1.0)
+      quick_search-core (~> 0)
+
+GIT
+  remote: https://github.com/umd-lib/quick_search-internet_archive_searcher
+  revision: 023d8668651e66b7c40af11600be34f52d237a1f
+  branch: develop
+  specs:
+    quick_search-internet_archive_searcher (0.1.0)
       quick_search-core (~> 0)
 
 GIT
@@ -31,6 +73,14 @@ GIT
       kaminari
       quick_search-core (~> 0)
       rsolr (= 2.2.1)
+
+GIT
+  remote: https://github.com/umd-lib/quick_search-maryland_map_searcher.git
+  revision: a84e9580d3ae11bcfbdd33a9cc342dc12f9caeea
+  branch: develop
+  specs:
+    quick_search-maryland_map_searcher (0.1.0)
+      quick_search-core (~> 0)
 
 GIT
   remote: https://github.com/umd-lib/quick_search-umd_theme.git
@@ -121,6 +171,8 @@ GEM
       io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
+    bibtex-ruby (4.4.7)
+      latex-decode (~> 0.0)
     bindex (0.5.0)
     bootsnap (1.4.1)
       msgpack (~> 1.0)
@@ -140,6 +192,12 @@ GEM
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
     chunky_png (1.3.11)
+    citeproc (1.0.9)
+      namae (~> 1.0)
+    citeproc-ruby (1.1.10)
+      citeproc (~> 1.0, >= 1.0.9)
+      csl (~> 1.5)
+    climate_control (0.2.0)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -165,6 +223,10 @@ GEM
       sprockets (< 4.0)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
+    csl (1.5.0)
+      namae (~> 1.0)
+    csl-styles (1.0.1.9)
+      csl (~> 1.0)
     docile (1.1.5)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
@@ -172,12 +234,31 @@ GEM
     dotenv-rails (2.2.2)
       dotenv (= 2.2.2)
       railties (>= 3.2, < 6.0)
+    ebsco-eds (1.0.7)
+      activesupport (~> 5.0)
+      bibtex-ruby (~> 4.0)
+      citeproc (>= 1.0.4, < 2.0)
+      citeproc-ruby (~> 1.0, >= 1.0.2)
+      climate_control (~> 0)
+      csl (~> 1.4)
+      csl-styles (~> 1.0, >= 1.0.1.5)
+      dotenv (~> 2.2)
+      faraday (~> 0)
+      faraday-detailed_logger (~> 2.0)
+      faraday_middleware (~> 0.11)
+      net-http-persistent (~> 2.9)
+      require_all (~> 1.3)
+      sanitize (~> 4.5, >= 4.5.0)
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     erubi (1.8.0)
     execjs (2.7.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
+    faraday-detailed_logger (2.1.3)
+      faraday (~> 0.8)
+    faraday_middleware (0.13.1)
+      faraday (>= 0.7.4, < 1.0)
     fastimage (2.1.5)
     ffi (1.11.1)
     font-awesome-sass (4.7.0)
@@ -220,6 +301,7 @@ GEM
       activerecord
       kaminari-core (= 1.1.1)
     kaminari-core (1.1.1)
+    latex-decode (0.3.1)
     link_header (0.0.8)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -250,10 +332,14 @@ GEM
     multi_json (1.13.1)
     multipart-post (2.1.1)
     mysql2 (0.5.2)
+    namae (1.0.1)
+    net-http-persistent (2.9.4)
     netrc (0.11.0)
     nio4r (2.3.1)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
+    nokogumbo (1.5.0)
+      nokogiri
     oclc-auth (1.0.0)
       json (~> 2.0, >= 2.0.3)
       rake (~> 10.4)
@@ -319,6 +405,7 @@ GEM
     rdf-xsd (3.0.1)
       rdf (~> 3.0)
     regexp_parser (1.3.0)
+    require_all (1.5.0)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -339,6 +426,10 @@ GEM
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
     rubyzip (1.2.2)
+    sanitize (4.6.6)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.4.4)
+      nokogumbo (~> 1.4)
     sass (3.4.25)
     sass-rails (5.0.7)
       railties (>= 4.0.0, < 6)
@@ -419,6 +510,7 @@ DEPENDENCIES
   chromedriver-helper
   coffee-rails (~> 4.2)
   dotenv-rails (~> 2.2.1)
+  ebsco-eds (~> 1.0.7)
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)
@@ -426,11 +518,17 @@ DEPENDENCIES
   oclc-auth (>= 1.0.0)
   pg (~> 0.18.4)
   puma (~> 3.11)
+  quick_search-archives_space_searcher!
   quick_search-core!
   quick_search-database_finder_searcher!
+  quick_search-drum_searcher!
+  quick_search-ebsco_discovery_service_api_searcher!
+  quick_search-fedora_searcher!
+  quick_search-internet_archive_searcher!
   quick_search-lib_answers_searcher!
   quick_search-lib_guides_searcher!
   quick_search-library_website_searcher!
+  quick_search-maryland_map_searcher!
   quick_search-umd_theme!
   quick_search-world_cat_discovery_api_searcher!
   rails (~> 5.2.2, >= 5.2.2.1)

--- a/README.md
+++ b/README.md
@@ -229,10 +229,16 @@ resets the "Gemfile.lock" to the latest commits for the searchers:
 ```
 > cd searchumd
 > bundle update quick_search-core
+> bundle update quick_search-archives_space_searcher
+> bundle update quick_search-database_finder_searcher
+> bundle update quick_search-drum_searcher
+> bundle update quick_search-ebsco_discovery_service_api_searcher
+> bundle update quick_search-fedora_searcher
+> bundle update quick_search-internet_archive_searcher
 > bundle update quick_search-lib_answers_searcher
 > bundle update quick_search-lib_guides_searcher
-> bundle update quick_search-database_finder_searcher
 > bundle update quick_search-library_website_searcher
+> bundle update quick_search-maryland_map_searcher
 > bundle update quick_search-world_cat_discovery_api_searcher
 > bundle update quick_search-umd_theme
 ```

--- a/app/views/quick_search/search/index.html.erb
+++ b/app/views/quick_search/search/index.html.erb
@@ -26,31 +26,55 @@
 </div>
 <div class="quicksearch-ga-click-tracking">
     <div class="row articles-catalog">
-        <div class="small-12 medium-6 columns catalog module">
-            <%= render_module(@world_cat_discovery_api, 'world_cat_discovery_api') %>
-        </div>
-        <div class="small-12 medium-6 columns catalog module">
-            <%= render_module(@world_cat_discovery_api_article, 'world_cat_discovery_api_article') %>
-        </div>
-        <hr>
+      <div class="small-12 medium-3 columns catalog module">
+        <%= render_module(@archives_space, 'archives_space') %>
+      </div>
+      <div class="small-12 medium-3 columns catalog module">
+        <%= render_module(@database_finder, 'database_finder') %>
+      </div>
+      <div class="small-12 medium-3 columns catalog module">
+        <%= render_module(@DRUM, 'DRUM') %>
+      </div>
+      <div class="small-12 medium-3 columns catalog module">
+        <%= render_module(@ebsco_discovery_service_api, 'ebsco_discovery_service_api') %>
+      </div>
+      <hr>
     </div>
     <div class="row articles-catalog">
-        <div class="small-12 medium-6 columns catalog module">
-          <%= render_module(@lib_guides, 'lib_guides') %>
-        </div>
-        <div class="small-12 medium-6 columns catalog module">
-            <%= render_module(@database_finder, 'database_finder') %>
-        </div>
-        <hr>
+      <div class="small-12 medium-3 columns catalog module">
+        <%= render_module(@ebsco_discovery_service_api_article, 'ebsco_discovery_service_api_article') %>
+      </div>
+      <div class="small-12 medium-3 columns catalog module">
+        <%= render_module(@fedora, 'fedora') %>
+      </div>
+      <div class="small-12 medium-3 columns catalog module">
+        <%= render_module(@internet_archive, 'internet_archive') %>
+      </div>
+      <div class="small-12 medium-3 columns catalog module">
+        <%= render_module(@lib_guides, 'lib_guides') %>
+      </div>
+      <hr>
     </div>
     <div class="row articles-catalog">
-        <div class="small-12 medium-6 columns catalog module">
-          <%= render_module(@lib_answers, 'lib_answers') %>
-        </div>
-        <div class="small-12 medium-6 columns catalog module">
-            <%= render_module(@library_website, 'library_website') %>
-        </div>
-        <hr>
+      <div class="small-12 medium-3 columns catalog module">
+        <%= render_module(@lib_answers, 'lib_answers') %>
+      </div>
+      <div class="small-12 medium-3 columns catalog module">
+        <%= render_module(@library_website, 'library_website') %>
+      </div>
+      <div class="small-12 medium-3 columns catalog module">
+        <%= render_module(@maryland_map, 'maryland_map') %>
+      </div>
+      <div class="small-12 medium-3 columns catalog module">
+        <%= render_module(@world_cat_discovery_api, 'world_cat_discovery_api') %>
+      </div>
+      <hr>
+    </div>
+    <div class="row articles-catalog">
+      <div class="small-12 medium-3 columns catalog module">
+        <%= render_module(@world_cat_discovery_api_article, 'world_cat_discovery_api_article') %>
+      </div>
+      <hr>
     </div>
     <div class="row website-faq">
         <div class="small-12 columns"><h4 class='section-description'>Information About the Libraries</h4></div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,64 +30,68 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
-
-  lib_answers_search:
-    display_name: "FAQs from Ask Us!"
-    short_display_name: "FAQs from Ask Us!"
-    search_form_placeholder: "Search FAQs from Ask Us!"
-    module_callout: "Search FAQs from Ask Us!"
-    error_service_message: "searching FAQs from Ask Us!"
-    no_results_service_message: "a different search from FAQs from Ask Us!"
-    # no_results_link now configured in searcher configuration YAML file
-    no_results_link:
-
-  lib_guides_search:
-    display_name: "Research Guides"
-    short_display_name: "Research Guides"
-    search_form_placeholder: "Search Research Guides"
-    module_callout: "Search Research Guides"
-    error_service_message: "searching Research Guides"
-    no_results_service_message: "a different search from Research Guides"
+  archives_space_search:
     # no_results_link now configured in searcher configuration YAML file
     no_results_link:
 
   database_finder_search:
-    display_name: "Databases"
-    short_display_name: "Databases"
-    search_form_placeholder: "Search Databases"
-    module_callout: "Search Databases"
-    error_service_message: "searching Databases"
-    no_results_service_message: "a different search from Databases"
-    # no_results_link configured in searcher configuration YAML file
+    # no_results_link now configured in searcher configuration YAML file
+    no_results_link:
+
+  DRUM_search:
+    # no_results_link now configured in searcher configuration YAML file
+    no_results_link:
+
+  ebsco_discovery_service_api_search:
+    # no_results_link now configured in searcher configuration YAML file
+    no_results_link:
+
+  ebsco_discovery_service_api_article_search:
+    display_name: "EBSCO Discovery API Article"
+    short_display_name: "EBSCO Discovery API Article"
+    search_form_placeholder: "Search EBSCO Discovery API (Articles)"
+    module_callout: "Articles"
+    error_service_message: "searching EBSCO Discovery API (Articles)"
+    no_results_service_message: "a different search from EBSCO Discovery API (Articles)"
+    loaded_link:
+    # no_results_link now configured in searcher configuration YAML file
+    no_results_link:
+
+  fedora_search:
+    # no_results_link now configured in searcher configuration YAML file
+    no_results_link:
+
+  internet_archive_search:
+    # no_results_link now configured in searcher configuration YAML file
+    no_results_link:
+
+  lib_answers_search:
+    # no_results_link now configured in searcher configuration YAML file
+    no_results_link:
+
+  lib_guides_search:
+    # no_results_link now configured in searcher configuration YAML file
     no_results_link:
 
   library_website_search:
-    display_name: "Libraries' Website"
-    short_display_name: "Libraries' Website"
-    search_form_placeholder: "Search Libraries' Website"
-    module_callout: "Search Libraries' Website"
-    error_service_message: "searching Libraries' Website"
-    no_results_service_message: "a different search from Libraries' Website"
+    # no_results_link now configured in searcher configuration YAML file
+    no_results_link:
+
+  maryland_map_search:
     # no_results_link now configured in searcher configuration YAML file
     no_results_link:
 
   world_cat_discovery_api_search:
-    display_name: "Books and more"
-    short_display_name: "Books and more"
-    search_form_placeholder: "Search Books and more"
-    module_callout: "Search Books and more"
-    error_service_message: "searching Books and more"
-    no_results_service_message: "a different search for Books and more"
     # no_results_link now configured in searcher configuration YAML file
     no_results_link:
 
   world_cat_discovery_api_article_search:
-    display_name: "Articles"
-    short_display_name: "Articles"
+    display_name: "Worldcat Discovery API Article"
+    short_display_name: "Worldcat Discovery API Article"
     search_form_placeholder: "Search Worldcat Discovery API (Articles)"
     module_callout: "Articles"
     error_service_message: "searching Worldcat Discovery API (Articles)"
     no_results_service_message: "a different search from Worldcat Discovery API (Articles)"
     loaded_link:
+    # no_results_link now configured in searcher configuration YAML file
     no_results_link:

--- a/config/quick_search_config.yml
+++ b/config/quick_search_config.yml
@@ -18,11 +18,11 @@ defaults: &defaults
   #
   # See docs for more details: https://github.com/NCSU-Libraries/quick_search/blob/master/docs/configuration.md
 
-  searchers: [best_bets,world_cat_discovery_api,world_cat_discovery_api_article,lib_guides,database_finder,lib_answers,library_website]
+  searchers: [best_bets,archives_space,database_finder,DRUM,ebsco_discovery_service_api,ebsco_discovery_service_api_article,fedora,internet_archive,lib_guides,lib_answers,library_website,maryland_map,world_cat_discovery_api,world_cat_discovery_api_article]
 
   # Searchers listed in the "result type guide" bar that lists result types that were found for a given search
 
-  found_types: [world_cat_discovery_api,world_cat_discovery_api_article,lib_guides,database_finder,lib_answers,library_website]
+  found_types: [archives_space,database_finder,DRUM,ebsco_discovery_service_api,ebsco_discovery_service_api_article,fedora,internet_archive,lib_guides,lib_answers,library_website,maryland_map,world_cat_discovery_api,world_cat_discovery_api_article]
 
   per_page: 3
   max_per_page: 50

--- a/config/searchers/archives_space_config.yml
+++ b/config/searchers/archives_space_config.yml
@@ -1,0 +1,56 @@
+# Configuration
+#
+# Replace the following placeholders with the correct values for
+# your installation.
+#
+# search_url: The URL for performing the search
+# loaded_link: URL to the 'native' interface
+# object_types: aspace object types to return. these are mapped to Solr types:
+# field queries
+# query_params: params to be passed to Solr
+# native_query_params: params to be passed to the loaded_link.
+
+defaults: &defaults
+  search_url: '<%= ENV['ARCHIVES_SPACE_SOLR_URL'] %>'
+  loaded_link: '<%= ENV['ARCHIVES_SPACE_URL'] %>/search'
+  no_results_link: '<%= ENV['ARCHIVES_SPACE_URL'] %>'
+  object_types:
+    - subject
+    - classification
+    - accession
+    - repository
+    - resource
+    - agent
+    - digital_object
+    - archival_object
+  query_params:
+    'q.op': AND
+    q:
+      - 'publish:(true)'
+      - 'types:(pui)' 
+    fq:
+      - '-exclude_by_default:true'
+      - 'publish:true'
+    rows: 3
+    wt: 'json'
+  native_query_params:
+    op: ['']
+    q: []
+    uft8: '✓'
+    limit: ''
+    field: ['']
+    from_year: ['']
+    to_year: ['']
+    commit: 'Search' 
+
+development:
+  <<: *defaults
+
+test:
+  <<: *defaults
+
+staging:
+  <<: *defaults
+
+production:
+  <<: *defaults

--- a/config/searchers/drum_config.yml
+++ b/config/searchers/drum_config.yml
@@ -1,0 +1,28 @@
+# Configuration
+#
+# Replace the following placeholders with the correct values for
+# your installation.
+#
+# search_url: The URL for performing the search
+# native_url: Link to the 'native'/human interface
+# query_params => rpp: Number of results to display
+
+defaults: &defaults
+  search_url: '<%= ENV['DRUM_SITE_URL'] %>open-search/discover'
+  native_url: '<%= ENV['DRUM_SITE_URL'] %>discover'
+  no_results_link: '<%= ENV['DRUM_SITE_URL'] %>discover'
+  # Query params should be listed in "hash" format
+  query_params:
+    query: ''
+    rpp: 3
+development:
+  <<: *defaults
+
+test:
+  <<: *defaults
+
+staging:
+  <<: *defaults
+
+production:
+  <<: *defaults

--- a/config/searchers/ebsco_discovery_service_api_article_config.yml
+++ b/config/searchers/ebsco_discovery_service_api_article_config.yml
@@ -1,0 +1,40 @@
+# Configuration
+#
+# Replace the following placeholders with the correct values for
+# your installation.
+#
+# <YOUR_WSKEY>: The "wskey" provided by OCLC
+# <YOUR_SECRET>: The "secret" provided by OCLC
+# <AUTHENTICATING_INSTITUTION_ID>: The "authenticating institution id" provided
+#                                 by OCLC
+# <CONTEXT_INSTITUTION_ID>: The "context institution id" provided
+#                           by OCLC (typically the same as the institution id)
+# <LOADED_LINK>: The base URL to send the query to
+# <URL_LINK>: The base URL for result links
+# <NO_RESULTS_LINK>: The URL to use when no results are found
+
+defaults: &defaults
+  # The following propreties are common to both searchers. If the
+  # ebsco_discovery_service_api searcher is not being used, copy these
+  # properties into the ebsco_discovery_service_api_article_config.yml file
+  username: <%= ENV['EBSCO_DISCOVERY_SERVICE_API_USERNAME'] %>
+  password: <%= ENV['EBSCO_DISCOVERY_SERVICE_API_PASSWORD'] %>
+  enable_article_filter: true
+
+  # ebsco_discovery_service_api-specific properties
+  loaded_link: 'https://widgets.ebscohost.com/prod/search/?direct=true&scope=site&site=eds-live&authtype=ip,guest&custid=umarylnd&groupid=main&profile=eds&facet=AcademicJournals&bquery='
+  url_link: 'https://proxy-um.researchport.umd.edu/login?url=https://search.ebscohost.com/login.aspx?direct=true&site=eds-live'
+  doi_link: 'https://proxy-um.researchport.umd.edu/login?url=https://doi.org/'
+  no_results_link: 'https://proxy-um.researchport.umd.edu/login?url=https://search.ebscohost.com/login.aspx?direct=true&site=eds-live'
+
+development:
+  <<: *defaults
+
+test:
+  <<: *defaults
+
+staging:
+  <<: *defaults
+
+production:
+  <<: *defaults

--- a/config/searchers/ebsco_discovery_service_api_config.yml
+++ b/config/searchers/ebsco_discovery_service_api_config.yml
@@ -1,0 +1,38 @@
+# Configuration
+#
+# Replace the following placeholders with the correct values for
+# your installation.
+#
+# <YOUR_WSKEY>: The "wskey" provided by OCLC
+# <YOUR_SECRET>: The "secret" provided by OCLC
+# <AUTHENTICATING_INSTITUTION_ID>: The "authenticating institution id" provided
+#                                 by OCLC
+# <CONTEXT_INSTITUTION_ID>: The "context institution id" provided
+#                           by OCLC (typically the same as the institution id)
+# <LOADED_LINK>: The base URL to send the query to
+# <URL_LINK>: The base URL for result links
+# <NO_RESULTS_LINK>: The URL to use when no results are found
+
+defaults: &defaults
+  # The following propreties are common to both searchers. If the
+  # ebsco_discovery_service_api searcher is not being used, copy these
+  # properties into the ebsco_discovery_service_api_article_config.yml file
+  username: <%= ENV['EBSCO_DISCOVERY_SERVICE_API_USERNAME'] %>
+  password: <%= ENV['EBSCO_DISCOVERY_SERVICE_API_PASSWORD'] %>
+
+  # ebsco_discovery_service_api-specific properties
+  loaded_link: 'https://proxy-um.researchport.umd.edu/login?url=https://search.ebscohost.com/login.aspx?direct=true&site=eds-live&bquery='
+  url_link: 'https://proxy-um.researchport.umd.edu/login?url=https://search.ebscohost.com/login.aspx?direct=true&site=eds-live'
+  no_results_link: 'https://proxy-um.researchport.umd.edu/login?url=https://search.ebscohost.com/login.aspx?direct=true&site=eds-live'
+
+development:
+  <<: *defaults
+
+test:
+  <<: *defaults
+
+staging:
+  <<: *defaults
+
+production:
+  <<: *defaults

--- a/config/searchers/fedora_config.yml
+++ b/config/searchers/fedora_config.yml
@@ -1,0 +1,26 @@
+# Configuration
+#
+# Replace the following placeholders with the correct values for
+# your installation.
+#
+# <SEARCH_URL>: The URL for performing the search
+# <QUERY_PARAMS>: Any HTTP query parameters that should be included in the search
+# <WEBSITE_SEARCH_URL>: The URL for the website search page (with query parameter)
+
+defaults: &defaults
+  search_url: "<%= ENV['FEDORA_HIPPO_SITE_URL'] %><%= ENV['FEDORA_HIPPO_SITE_SEARCH_PATH'] %>/json"
+  query_params: '?query='
+  no_results_link: "<%= ENV['FEDORA_HIPPO_SITE_URL'] %><%= ENV['FEDORA_HIPPO_SITE_SEARCH_PATH'] %>"
+  loaded_link: "<%= ENV['FEDORA_HIPPO_SITE_URL'] %><%= ENV['FEDORA_HIPPO_SITE_SEARCH_PATH'] %>"
+
+development:
+  <<: *defaults
+
+test:
+  <<: *defaults
+
+staging:
+  <<: *defaults
+
+production:
+  <<: *defaults

--- a/config/searchers/internet_archive_config.yml
+++ b/config/searchers/internet_archive_config.yml
@@ -1,0 +1,37 @@
+# Configuration
+#
+# Replace the following placeholders with the correct values for
+# your installation.
+#
+# search_url: The URL for performing the search
+# loaded_link: link prefix for resolved records
+# no_results_link: link to the native search ui
+# query_params: see https://archive.org/advancedsearch.php
+# ( you can limit to collections using q params.
+#   i.e. q: collection:(university_maryland_cp) )
+defaults: &defaults
+  search_url: 'https://archive.org/advancedsearch.php'
+  loaded_link: 'https://archive.org/search.php'
+  no_results_link: 'https://archive.org/details/university_maryland_cp'
+  # Query params should be listed in "hash" format
+  query_params:
+    q: ['collection:(university_maryland_cp)']
+    fl: 
+      - title
+      - description
+      - identifier
+    rows: 3
+    output: json
+    sort: []
+
+development:
+  <<: *defaults
+
+test:
+  <<: *defaults
+
+staging:
+  <<: *defaults
+
+production:
+  <<: *defaults

--- a/config/searchers/maryland_map_config.yml
+++ b/config/searchers/maryland_map_config.yml
@@ -1,0 +1,26 @@
+# Configuration
+#
+# Replace the following placeholders with the correct values for
+# your installation.
+#
+# <SEARCH_URL>: The URL for performing the search
+# <QUERY_PARAMS>: Any HTTP query parameters that should be included in the search
+# <HIPPO_SITE_URL>: The URL for the Hippo site
+
+defaults: &defaults
+  search_url: "<%= ENV['MARYLAND_MAP_HIPPO_SITE_URL'] %>restservices/v1/mdmap/search"
+  query_params: '?q='
+  loaded_link: "<%= ENV['MARYLAND_MAP_HIPPO_SITE_URL'] %>mdmap/search?queryScope=all&query="
+  no_results_link: "<%= ENV['MARYLAND_MAP_HIPPO_SITE_URL'] %>mdmap/search/"
+
+development:
+  <<: *defaults
+
+test:
+  <<: *defaults
+
+staging:
+  <<: *defaults
+
+production:
+  <<: *defaults

--- a/env_example
+++ b/env_example
@@ -34,15 +34,34 @@ PROD_DATABASE_PORT=5432
 # Pool size
 PROD_DATABASE_POOL=10
 
-# --- config/searchers/world_cat_discovery_api_config.yml
-# The WorldCat Discovery API institution id
-WORLD_CAT_DISCOVERY_API_INSTITUTION_ID=
+# --- config/searchers/archives_space_config
+# The ArchivesSpace search endpoint
+ARCHIVES_SPACE_URL=
 
-# The WorldCat Discovery API wskey
-WORLD_CAT_DISCOVERY_API_WSKEY=
+# The ArchivesSpace Solr search endpoint
+ARCHIVES_SPACE_SOLR_URL=
 
-# The WorldCat Discovery API wskey
-WORLD_CAT_DISCOVERY_API_SECRET=
+# -- config/searchers/database_finder_config.yml
+# The base URL for the Hippo website
+DATABASE_FINDER_HIPPO_SITE_URL=
+
+# --- config/searchers/drum_config.yml
+# The URL for the DRUM site
+DRUM_SITE_URL=
+
+# --- config/searchers/ebsco_discovery_service_api_config.yml
+# The EBSCO Discovery Service API Username
+EBSCO_DISCOVERY_SERVICE_API_USERNAME=
+
+# The EBSCO Discovery Service Password
+EBSCO_DISCOVERY_SERVICE_API_PASSWORD=
+
+# --- config/searchers/fedora_config.yml
+# The base URL for performing Fedora searches using the Hippo CMS
+FEDORA_HIPPO_SITE_URL=
+
+# The URL path to native search interface
+FEDORA_HIPPO_SITE_SEARCH_PATH=searchnew
 
 # --- config/searchers/lib_answers_config.yml
 # The Institution ID for LibAnswers
@@ -55,10 +74,20 @@ LIB_GUIDES_SITE_ID=
 # The API key to use with LibGuides
 LIB_GUIDES_API_KEY=
 
-# -- config/searchers/database_finder_config.yml
-# The base URL for the Hippo website
-DATABASE_FINDER_HIPPO_SITE_URL=
-
 # -- config/searchers/library_website_config.yml
 # The Library Website Search Solr endpoint
 LIBRARY_WEBSITE_SEARCH_SOLR_URL=
+
+# -- config/searchers/maryland_map_config.yml
+# The base URL for the Hippo website
+MARYLAND_MAP_HIPPO_SITE_URL=
+
+# --- config/searchers/world_cat_discovery_api_config.yml
+# The WorldCat Discovery API institution id
+WORLD_CAT_DISCOVERY_API_INSTITUTION_ID=
+
+# The WorldCat Discovery API wskey
+WORLD_CAT_DISCOVERY_API_WSKEY=
+
+# The WorldCat Discovery API wskey
+WORLD_CAT_DISCOVERY_API_SECRET=


### PR DESCRIPTION
Moved the following searchers into searchumd:

From "searchumd-special":

* quick_search-archives_space_searcher
* quick_search-drum_searcher
* quick_search-internet_archive_searcher
* quick_search-fedora_searcher
* quick_search-maryland_map_searcher

from searchumd "eds-develop" branch:

* quick_search-ebsco_discovery_service_api_searcher

Added the searcher config files for the added searchers.

Modified the searcher page to show all the searchers.

Re-ordered searcher configuration in "env_example" so searchers would be
in alphabetical order.

Removed en.yml customizations, except where needed to display the
correct text. This was done so that on the searcher results page, it was
clearer which searcher was returning which results.

https://issues.umd.edu/browse/LIBSEARCH-150