### PR TITLE
LIBSEARCH-148. Added Nutch "umd-index-title" index filter

### DIFF
--- a/docker_config/nutch/conf/nutch-site.xml
+++ b/docker_config/nutch/conf/nutch-site.xml
@@ -6,7 +6,7 @@
 <configuration>
   <property>
     <name>plugin.includes</name>
-    <value>protocol-http|urlfilter-(regex|validator)|parse-(html|tika)|index-(basic|anchor|metadata)|indexer-solr|scoring-opic|urlnormalizer-(pass|regex|basic)|umd-parsefilter-jsonld</value>
+    <value>protocol-http|urlfilter-(regex|validator)|parse-(html|tika)|index-(basic|anchor|metadata)|indexer-solr|scoring-opic|urlnormalizer-(pass|regex|basic)|umd-parsefilter-jsonld|umd-index-title</value>
     <description>
       Regular expression naming plugin directory names to
       include.  Any plugin not matching this expression is excluded.
@@ -15,7 +15,7 @@
       and basic indexing and search plugins.
     </description>
   </property>
-  
+
   <property>
     <name>http.agent.name</name>
     <value>http.umd_libraries.umdsearch_crawler</value>
@@ -30,7 +30,7 @@
   <property>
     <name>http.agent.url</name>
     <value>https://www.lib.umd.edu/</value>
-    <description>A URL to advertise in the User-Agent header.  This will 
+    <description>A URL to advertise in the User-Agent header.  This will
      appear in parenthesis after the agent name. Custom dictates that this
      should be a URL of a page explaining the purpose and behavior of this
      crawler.
@@ -47,7 +47,7 @@
   <property>
     <name>http.agent.version</name>
     <value>Nutch-1.14</value>
-    <description>A version string to advertise in the User-Agent 
+    <description>A version string to advertise in the User-Agent
      header.</description>
   </property>
   <property>
@@ -76,9 +76,9 @@
   <property>
     <name>fetcher.server.delay</name>
     <value>1.0</value>
-    <description>The number of seconds the fetcher will delay between 
+    <description>The number of seconds the fetcher will delay between
      successive requests to the same server. Note that this might get
-     overridden by a Crawl-Delay from a robots.txt and is used ONLY if 
+     overridden by a Crawl-Delay from a robots.txt and is used ONLY if
      fetcher.threads.per.queue is set to 1.
      </description>
   </property>


### PR DESCRIPTION
Added UMD custom "umd-index-title" index filter to populate the
"title" field with the filename of a PDF file, if a title cannot
otherwise be found.

Also removed extraneous whitespace.

https://issues.umd.edu/browse/LIBSEARCH-148