### PR TITLE
LIBSEARCH-168. Improved Nutch fetching and parsing

### DIFF
--- a/docker_config/nutch/conf/nutch-site.xml
+++ b/docker_config/nutch/conf/nutch-site.xml
@@ -89,4 +89,23 @@
     metadata to generate fields.
     </description>
   </property>
+
+  <property>
+    <name>http.content.limit</name>
+    <value>-1</value>
+    <description>The length limit for downloaded content using the http://
+    protocol, in bytes. If this value is nonnegative (>=0), content longer
+    than it will be truncated; otherwise, no truncation at all. Do not
+    confuse this setting with the file.content.limit setting.
+    </description>
+  </property>
+
+  <property>
+    <name>db.max.outlinks.per.page</name>
+    <value>-1</value>
+    <description>The maximum number of outlinks that we'll process for a page.
+    If this value is nonnegative (>=0), at most db.max.outlinks.per.page outlinks
+    will be processed for a page; otherwise, all outlinks will be processed.
+    </description>
+  </property>
 </configuration>

--- a/docker_config/nutch/conf/regex-urlfilter.txt
+++ b/docker_config/nutch/conf/regex-urlfilter.txt
@@ -42,6 +42,10 @@
 -^https?://(www\.)*lib\.umd\.edu/plantpatents/id
 -^https?://(www\.)*lib\.umd\.edu/plantpatents/binaries
 
+# reject anything under binaries/content, as we typically cannot parse it
+# TODO: Figure out why PDF parsing seems to always fail
+-^https?://(www\.)*lib\.umd\.edu/binaries/content
+
 # accept UMD Libraries URLs
 +^https?://(www\.)*lib\.umd\.edu
 

--- a/docker_config/nutch/conf/regex-urlfilter.txt
+++ b/docker_config/nutch/conf/regex-urlfilter.txt
@@ -42,10 +42,6 @@
 -^https?://(www\.)*lib\.umd\.edu/plantpatents/id
 -^https?://(www\.)*lib\.umd\.edu/plantpatents/binaries
 
-# reject anything under binaries/content, as we typically cannot parse it
-# TODO: Figure out why PDF parsing seems to always fail
--^https?://(www\.)*lib\.umd\.edu/binaries/content
-
 # accept UMD Libraries URLs
 +^https?://(www\.)*lib\.umd\.edu
 

--- a/docker_config/nutch/conf/regex-urlfilter.txt
+++ b/docker_config/nutch/conf/regex-urlfilter.txt
@@ -38,6 +38,10 @@
 # reject DBfinder URLs
 -^https?://(www\.)*lib\.umd\.edu/dbfinder
 
+# reject Plant Patents URLs (actual patents)
+-^https?://(www\.)*lib\.umd\.edu/plantpatents/id
+-^https?://(www\.)*lib\.umd\.edu/plantpatents/binaries
+
 # accept UMD Libraries URLs
 +^https?://(www\.)*lib\.umd\.edu
 

--- a/docker_config/nutch/sitemaps/sitemaps.txt
+++ b/docker_config/nutch/sitemaps/sitemaps.txt
@@ -1,0 +1,1 @@
+https://www.lib.umd.edu/sitemap.xml

--- a/docker_config/nutch/umd_crawl
+++ b/docker_config/nutch/umd_crawl
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Sample usage
+# > ./umd_crawl http://solr_app:8983/solr/nutch 10
+
+# Verify number of arguments, and print usage message if needed
+[ $# -lt 2 ] && { echo "Usage: $0 <SOLR_SERVER_URL> <NUM_ROUNDS>"; exit 1; }
+
+SOLR_SERVER_URL=$1
+NUM_ROUNDS=$2
+SITEMAP_URL_DIR=sitemaps/
+CRAWL_DB=LibCrawl/
+
+bin/nutch sitemap $CRAWL_DB/crawldb -sitemapUrls $SITEMAP_URL_DIR
+bin/crawl -i -D solr.server.url=$SOLR_SERVER_URL $CRAWL_DB $NUM_ROUNDS

--- a/docker_config/nutch/urls/seed.txt
+++ b/docker_config/nutch/urls/seed.txt
@@ -1,1 +1,0 @@
-https://www.lib.umd.edu/


### PR DESCRIPTION
Modified Nutch configuration to improve fetching and parsing:

* The entire document is parsed for links, instead of just the first 64k
* All links in the document are fetched, instead of just the first 100
* The individual patent pages in "Plant Patents" have been excluded.
* Nutch now retrieves the sitemap.xml from the production website for its seed URLs.
* Added "umd_crawl" script to Nutch configuration to make Nutch crawl more flexible (i.e. not limited to what is possible with the "bin/crawl" command in Nutch.

https://issues.umd.edu/browse/LIBSEARCH-168