### PR TITLE
LIBSEARCH-182. Replaced hard-coded URL in config with .env property

### DIFF
--- a/config/searchers/lib_guides_config.yml
+++ b/config/searchers/lib_guides_config.yml
@@ -1,5 +1,5 @@
 defaults: &defaults
-  base_url: 'http://lgapi-us.libapps.com/1.1/guides/?key='
+  base_url: '<%= ENV['LIB_GUIDES_URL'] %>?key='
   query_params: '&site_id=<%= ENV['LIB_GUIDES_SITE_ID'] %>&sort_by=relevance&search_terms='
   loaded_link: 'http://lib.guides.umd.edu/srch.php?q='
   key: <%= ENV['LIB_GUIDES_API_KEY'] %>

--- a/env_example
+++ b/env_example
@@ -68,6 +68,9 @@ FEDORA_HIPPO_SITE_SEARCH_PATH=searchnew
 LIB_ANSWERS_IID=
 
 # --- config/searchers/lib_guides_config.yml
+# The URL for the LibGuides API
+LIB_GUIDES_URL=https://lgapi-us.libapps.com/1.1/guides/
+
 # The Site ID to use with LibGuides
 LIB_GUIDES_SITE_ID=
 


### PR DESCRIPTION
Replaced the hard-coded URL in "config/searchers/lib_guides_config.yml"
with a "LIB_GUIDES_URL" property in the .env file.

https://issues.umd.edu/browse/LIBSEARCH-182