### PR TITLE
LIBSEARCH-193. Added "JVM_MAX_RAM_PERCENTAGE" to Nutch script

### DIFF
--- a/docker_config/nutch/umd_crawl
+++ b/docker_config/nutch/umd_crawl
@@ -6,10 +6,13 @@
 # Verify number of arguments, and print usage message if needed
 [ $# -lt 2 ] && { echo "Usage: $0 <SOLR_SERVER_URL> <NUM_ROUNDS>"; exit 1; }
 
+# Default to 90% of RAM usage, if no other value is specified
+JVM_MAX_RAM_PERCENTAGE=${JVM_MAX_RAM_PERCENTAGE:=90.0}
+
 SOLR_SERVER_URL=$1
 NUM_ROUNDS=$2
 SITEMAP_URL_DIR=sitemaps/
 CRAWL_DB=LibCrawl/
 
 bin/nutch sitemap $CRAWL_DB/crawldb -sitemapUrls $SITEMAP_URL_DIR
-bin/crawl -i -D solr.server.url=$SOLR_SERVER_URL $CRAWL_DB $NUM_ROUNDS
+bin/crawl -i -D -XX:MaxRAMPercentage=$JVM_MAX_RAM_PERCENTAGE -D solr.server.url=$SOLR_SERVER_URL $CRAWL_DB $NUM_ROUNDS


### PR DESCRIPTION
Added a "JVM_MAX_RAM_PERCENTAGE" variable to the Nutch script, which
defaults to 90.0, if not otherwise set. Modified the start script to
supply the "JVM_MAX_RAM_PERCENTAGE" variable to the -XX:MaxRAMPercentage
Java system property, so that the JVM will use more than 25% of the
available RAM in the container.

https://issues.umd.edu/browse/LIBSEARCH-193