### PR TITLE
LIBSEARCH-200. Added lib_guides_database_searcher integration.

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,0 @@
-LIB_GUIDES_DATABASE_QUERY_TEMPLATE=https://lib.guides.umd.edu/process/az/dbsearch?action=520&site_id=1504&is_widget=0{&search}
-
-LIB_GUIDES_DATABASE_LOADED_LINK_TEMPLATE=https://lib.guides.umd.edu/az.php{?q}
-
-LIB_GUIDES_DATABASE_NO_RESULTS_LINK=https://lib.guides.umd.edu/az.php

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,5 @@
+LIB_GUIDES_DATABASE_QUERY_TEMPLATE=https://lib.guides.umd.edu/process/az/dbsearch?action=520&site_id=1504&is_widget=0{&search}
+
+LIB_GUIDES_DATABASE_LOADED_LINK_TEMPLATE=https://lib.guides.umd.edu/az.php{?q}
+
+LIB_GUIDES_DATABASE_NO_RESULTS_LINK=https://lib.guides.umd.edu/az.php

--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,10 @@ gem 'umd_open_url',
     git: 'https://github.com/umd-lib/umd_open_url',
     tag: '1.0.0'
 
+gem 'quick_search-lib_guides_database_searcher',
+    git: 'https://github.com/umd-lib/quick_search-lib_guides_database_searcher.git',
+    tag: 'develop'
+
 # Dependencies for the quick_search-world_cat_discovery_api_searcher initialization script
 gem 'oclc-auth', '>=1.0.0'
 gem 'worldcat-discovery', '>=1.2.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,16 @@ GIT
       quick_search-core (~> 0)
 
 GIT
+  remote: https://github.com/umd-lib/quick_search-lib_guides_database_searcher.git
+  revision: 3859ad69bc8f597f41e1542031e5d662f59c2cb8
+  tag: develop
+  specs:
+    quick_search-lib_guides_database_searcher (1.0.0)
+      addressable (~> 2.7)
+      quick_search-core (~> 0)
+      rails (~> 5.2.6)
+
+GIT
   remote: https://github.com/umd-lib/quick_search-lib_guides_searcher.git
   revision: 34b5276583f92cb341329c0f96cf1450cc8a396c
   tag: 1.0.1
@@ -424,6 +434,7 @@ DEPENDENCIES
   quick_search-core!
   quick_search-database_finder_searcher!
   quick_search-lib_answers_searcher!
+  quick_search-lib_guides_database_searcher!
   quick_search-lib_guides_searcher!
   quick_search-umd_theme!
   quick_search-world_cat_discovery_api_searcher!

--- a/app/views/quick_search/search/index.html.erb
+++ b/app/views/quick_search/search/index.html.erb
@@ -27,17 +27,20 @@
 <div class="quicksearch-ga-click-tracking">
   <div class="row articles-catalog">
     <div class="small-12 medium-3 columns catalog module">
+      <%= render_module(@lib_guides_database, 'lib_guides_database') %>
+    </div>
+    <div class="small-12 medium-3 columns catalog module">
       <%= render_module(@database_finder, 'database_finder') %>
     </div>
     <div class="small-12 medium-3 columns catalog module">
       <%= render_module(@lib_guides, 'lib_guides') %>
     </div>
-    <div class="small-12 medium-3 columns catalog module">
-      <%= render_module(@lib_answers, 'lib_answers') %>
-    </div>
     <hr>
   </div>
   <div class="row articles-catalog">
+    <div class="small-12 medium-3 columns catalog module">
+      <%= render_module(@lib_answers, 'lib_answers') %>
+    </div>
     <div class="small-12 medium-3 columns catalog module">
       <%= render_module(@world_cat_discovery_api, 'world_cat_discovery_api') %>
     </div>

--- a/config/quick_search_config.yml
+++ b/config/quick_search_config.yml
@@ -18,7 +18,7 @@ defaults: &defaults
   #
   # See docs for more details: https://github.com/NCSU-Libraries/quick_search/blob/master/docs/configuration.md
 
-  searchers: [best_bets,database_finder,lib_guides,lib_answers,world_cat_discovery_api,world_cat_discovery_api_article]
+  searchers: [best_bets,lib_guides_database,database_finder,lib_guides,lib_answers,world_cat_discovery_api,world_cat_discovery_api_article]
 
   # Searchers listed in the "result type guide" bar that lists result types that were found for a given search
 

--- a/config/searchers/lib_guides_database_config.yml
+++ b/config/searchers/lib_guides_database_config.yml
@@ -1,6 +1,15 @@
 defaults: &defaults
+  # RFC 6570 URI template for the LibGuides "API" search endpoint. The first
+  # variable in the template will be set to the user's current query when executing
+  # a search. Any additional variables will be ignored.
   query_template: "https://lib.guides.umd.edu/process/az/dbsearch?action=520&site_id=<%= ENV['LIB_GUIDES_SITE_ID'] %>&is_widget=0{&search}"
+
+  # RFC 6570 URI template for the LibGuides search page. The first variable in the
+  # template will be set to the user's current query when executing a search. Any
+  # additional variables will be ignored.
   loaded_link_template: "https://lib.guides.umd.edu/az.php{?q}"
+
+  # URL to link to when there are no search results for the user's current query.
   no_results_link: "https://lib.guides.umd.edu/az.php"
 
 development:

--- a/config/searchers/lib_guides_database_config.yml
+++ b/config/searchers/lib_guides_database_config.yml
@@ -1,0 +1,16 @@
+defaults: &defaults
+  query_template: "https://lib.guides.umd.edu/process/az/dbsearch?action=520&site_id=<%= ENV['LIB_GUIDES_SITE_ID'] %>&is_widget=0{&search}"
+  loaded_link_template: "https://lib.guides.umd.edu/az.php{?q}"
+  no_results_link: "https://lib.guides.umd.edu/az.php"
+
+development:
+  <<: *defaults
+
+test:
+  <<: *defaults
+
+staging:
+  <<: *defaults
+
+production:
+  <<: *defaults

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180221193511) do
+ActiveRecord::Schema.define(version: 2018_02_21_193511) do
 
   create_table "events", force: :cascade do |t|
     t.string "category"

--- a/env_example
+++ b/env_example
@@ -65,3 +65,17 @@ WORLD_CAT_DISCOVERY_API_SECRET=
 # --- config/searchers/world_cat_discovery_api_article_config.yml
 # The WorldCat Knowledge Base API OpenURL Resolve wskey
 WORLD_CAT_OPEN_URL_RESOLVER_WSKEY=
+
+# --- lib_guides_database_config.yml
+# RFC 6570 URI template for the LibGuides "API" search endpoint. The first
+# variable in the template will be set to the user's current query when executing
+# a search. Any additional variables will be ignored.
+LIB_GUIDES_DATABASE_QUERY_TEMPLATE=
+
+# RFC 6570 URI template for the LibGuides search page. The first variable in the
+# template will be set to the user's current query when executing a search. Any
+# additional variables will be ignored.
+LIB_GUIDES_DATABASE_LOADED_LINK_TEMPLATE=
+
+# URL to link to when there are no search results for the user's current query.
+LIB_GUIDES_DATABASE_NO_RESULTS_LINK=

--- a/env_example
+++ b/env_example
@@ -43,6 +43,7 @@ DATABASE_FINDER_HIPPO_SITE_URL=
 LIB_ANSWERS_IID=
 
 # --- config/searchers/lib_guides_config.yml
+# --- config/searchers/lib_guides_database_config.yml
 # The URL for the LibGuides API
 LIB_GUIDES_URL=https://lgapi-us.libapps.com/1.1/guides/
 
@@ -65,17 +66,3 @@ WORLD_CAT_DISCOVERY_API_SECRET=
 # --- config/searchers/world_cat_discovery_api_article_config.yml
 # The WorldCat Knowledge Base API OpenURL Resolve wskey
 WORLD_CAT_OPEN_URL_RESOLVER_WSKEY=
-
-# --- lib_guides_database_config.yml
-# RFC 6570 URI template for the LibGuides "API" search endpoint. The first
-# variable in the template will be set to the user's current query when executing
-# a search. Any additional variables will be ignored.
-LIB_GUIDES_DATABASE_QUERY_TEMPLATE=
-
-# RFC 6570 URI template for the LibGuides search page. The first variable in the
-# template will be set to the user's current query when executing a search. Any
-# additional variables will be ignored.
-LIB_GUIDES_DATABASE_LOADED_LINK_TEMPLATE=
-
-# URL to link to when there are no search results for the user's current query.
-LIB_GUIDES_DATABASE_NO_RESULTS_LINK=

--- a/test/searchers/loaded_link_test.rb
+++ b/test/searchers/loaded_link_test.rb
@@ -7,27 +7,37 @@ class LoadedLinkTest < ActiveSupport::TestCase
   test 'query parameter in loaded_link should be "percent-encoded"' do
     query_term = '"scientific american"'
 
-    percent_encoded_query_term = CGI.escape(query_term)
+    # Include both types of URI escaping for now, since either should be safe.
+
+    # URI-escaped with spaces encoded as "%20"
+    percent_encoded_query_term = Addressable::URI.escape(query_term)
+
+    # URI-escaped with spaces encoded as "+"
+    cgi_escaped_query_term = CGI.escape(query_term)
 
     # Map of searcher class name to HTTP query parameter holding the
     # query term in loaded_link
     searchers_with_query_param = {
       'QuickSearch::LibAnswersSearcher' => 'q',
+      'QuickSearch::LibGuidesDatabaseSearcher' => 'q',
       'QuickSearch::DatabaseFinderSearcher' => 'query',
       'QuickSearch::WorldCatDiscoveryApiSearcher' => 'queryString',
       'QuickSearch::WorldCatDiscoveryApiArticleSearcher' => 'queryString'
     }
 
-    searchers_with_query_param.each_pair do |key, value|
+    searchers_with_query_param.each_pair do |classname, param_name|
       # Instantiate class
-      klass = key.constantize
+      klass = classname.constantize
       searcher = klass.new(HTTPClient.new, query_term, 3)
 
       # Get loaded link
       loaded_link = searcher.loaded_link
 
-      expected_param = "#{value}=#{percent_encoded_query_term}"
-      assert loaded_link.include?(expected_param), "Failed for #{key}, loaded_link=#{loaded_link}"
+      expectation_msg = "#{classname}: Expected \"#{loaded_link}\" to include " \
+        "\"#{percent_encoded_query_term}\" or \"#{cgi_escaped_query_term}\""
+
+      assert loaded_link.include?("#{param_name}=#{percent_encoded_query_term}") ||
+             loaded_link.include?("#{param_name}=#{cgi_escaped_query_term}"), expectation_msg
     end
   end
 end


### PR DESCRIPTION
Gemfile pulls in the "develop" branch of the quick_search-lib_guides_database_searcher gem from GitHub.

https://issues.umd.edu/browse/LIBSEARCH-200