### PR TITLE
LIBSEARCH-206. SSL Root CA certification fix

### DIFF
--- a/config/initializers/modify_http_client_to_use_system_certs.rb
+++ b/config/initializers/modify_http_client_to_use_system_certs.rb
@@ -1,0 +1,15 @@
+require 'httpclient'
+
+# "Monkey-patching" the HTTPClient class to use system SSL CA certificates,
+# instead of the "http_library" built-in CA certificates, which are very old.
+#
+# See https://github.com/nahi/httpclient/issues/445#issuecomment-931465432
+class HTTPClient
+  alias original_initialize initialize
+
+  def initialize(*args, &block)
+    original_initialize(*args, &block)
+    # Force use of the default system CA certs (instead of the 6 year old bundled ones)
+    @session_manager&.ssl_config&.set_default_paths
+  end
+end


### PR DESCRIPTION
On October 1, 2021, a root CA certificate that the "http_client" relied
on for verifying SSL certificates expired. The "http_client" ships with
its own set of "trusted" root CA certificates which apparently haven't
been updated for a number of years.

The expired certificate was preventing a number of searchers from making
HTTP requests.

As at least a short-term fixed, followed the suggestion in
"http_client" issue 445 to "monkey-patch" the HTTPClient class to
use the CA certificates from the system.

https://issues.umd.edu/browse/LIBSEARCH-206