### PR TITLE
LIBSEARCH-205. Fixed searchumd GUI when port forwarding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,7 @@ COPY  --chown=app:app . /home/app/webapp/
 # Copy Rails application start script
 COPY --chown=app:app docker_config/searchumd/rails_start.sh /home/app/webapp
 
-ENV RAILS_RELATIVE_URL_ROOT=/search
-ENV SCRIPT_NAME=/search
+ENV RAILS_RELATIVE_URL_ROOT=/
 
 # The following SECRET_KEY_BASE variable is used so that the
 # "assets:precompile" command will run run without throwing an error.


### PR DESCRIPTION
Replaced "/search" in "RAILS_RELATIVE_URL_ROOT" environment variable
with "/", because the "/search" subpath is no longer necessary.
The "/search" subpath was used when searchumd was its own front-end
application, in order allow a search home page to be provided. Since
searchumd is no longer a front-end application, but is used purely
as a backemd, the "/search" subpath is not needed.

Also removed the "SCRIPT_NAME" environment variable, because it does
not appear to be used, or necessary.

https://issues.umd.edu/browse/LIBSEARCH-205